### PR TITLE
Change source for git clone in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,7 @@ Please be aware that SciRuby and NMatrix are in *PRE-ALPHA* status. If you're th
 
 From the command line,
 
-    git clone git@github.com:mohawkjohn/nmatrix.git
+    git clone https://github.com/SciRuby/nmatrix.git
     cd nmatrix
     bundle
     rake compile


### PR DESCRIPTION
This way the installation guide points to SciRuby's repo.

Actually, I'm having some problems building extensions, but I intend to help with some linear systems (matrix exponential, for example). This is my first pull request and I'm just following the GitHub's guide; sorry if there's something wrong.

Thank you. :)
