### PR TITLE
Size helpers #rows and #cols

### DIFF
--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -86,6 +86,14 @@ class NMatrix
 	end
 	alias :pp :pretty_print
 
+  # These shortcuts use #shape to return the number of rows and columns.
+  def rows
+    shape[0]
+  end
+  
+  def cols
+    shape[1]
+  end
 
   # Use LAPACK to calculate the inverse of the matrix (in-place). Only works on dense matrices.
   #

--- a/spec/nmatrix_spec.rb
+++ b/spec/nmatrix_spec.rb
@@ -288,6 +288,11 @@ describe NMatrix do
         NMatrix.new(storage_type, [3,2,8], 0).shape.should == [3,2,8]
         NMatrix.new(storage_type, [3,2,8], 0).dim.should  == 3
       end
+      
+      it "returns number of rows and columns" do
+        NMatrix.new(storage_type, [7, 4], 3).rows.should == 7
+        NMatrix.new(storage_type, [7, 4], 3).cols.should == 4
+      end
     end unless storage_type == :yale
   end
 


### PR DESCRIPTION
These are the helpers I described last week to @mohawkjohn. It's basically syntactic sugar for `#shape`, but I found them to help create more readable scripts.

And the slowdown for calling one method (and possibly caching the number of rows/columns) isn't so great, compared to the complexity of most of the matrix operations we have.
