### PR TITLE
Added #row shortcut for NMatrix

### DIFF
--- a/lib/nmatrix/shortcuts.rb
+++ b/lib/nmatrix/shortcuts.rb
@@ -314,6 +314,29 @@ as dimension."
       self[0 ... self.shape[0], column_number]
     end
   end
+  
+  #
+  # call-seq:
+  #     row(row_number) -> NMatrix
+  #     row(row_number, get_by) -> NMatrix
+  #
+  # * *Arguments* :
+  #   - +row_number+ -> Integer.
+  #   - +get_by+ -> Type of slicing to use, +:copy+ or +:reference+.
+  # * *Returns* :
+  #   - A NMatrix representing the requested row .
+  #
+  def row(row_number, get_by = :copy)
+    unless [:copy, :reference].include?(get_by)
+      raise ArgumentError, "row() 2nd parameter must be :copy or :reference"
+    end
+    
+    if get_by == :copy
+      self.slice(row_number, 0 ... self.shape[1])
+    else # by reference
+      self[row_number, 0 ... self.shape[1]]
+    end    
+  end
 end
 
 class NVector < NMatrix

--- a/spec/shortcuts_spec.rb
+++ b/spec/shortcuts_spec.rb
@@ -158,6 +158,21 @@ describe NMatrix do
     
     expect { m.column(1, :derp) }.to raise_error
   end
+  
+  it "row() returns a NMatrix" do
+    m = NMatrix.random(3)
+    
+    m.row(2).is_a?(NMatrix).should be_true
+  end
+  
+  it "row() accepts a second parameter (only :copy or :reference)" do
+    m = NMatrix.random(3)
+    
+    expect { m.row(1, :copy) }.to_not raise_error
+    expect { m.row(1, :reference) }.to_not raise_error
+    
+    expect { m.row(1, :derp) }.to raise_error
+  end
 end
 
 describe "NVector" do


### PR DESCRIPTION
The same idea as #column. Nothing very complicated, just slice a matrix and return the contents as a NMatrix.

Obviously, it doesn't introduce any problems with `rake spec` and passes all the tests I wrote.
