### PR TITLE
Fixed bug in NVector shortcut

### DIFF
--- a/lib/nmatrix/shortcuts.rb
+++ b/lib/nmatrix/shortcuts.rb
@@ -419,9 +419,9 @@ class NVector < NMatrix
       rng = Random.new
 
       random_values = []
-      dim.times { |i| random_values << rng.rand }
+      size.times { |i| random_values << rng.rand }
       
-      NVector.new(dim, random_values, :float64)
+      NVector.new(size, random_values, :float64)
     end
 
     #


### PR DESCRIPTION
While refactoring, I left a small mistake: just a variable that wasn't renamed everywhere it should have been. Thanks to @masaomi's revision of the shortcuts' specs, I found it and this is the fix.

With this change, all specs in shortcuts_specs.rb are passing.
