### PR TITLE
Cleanup whitespace

### DIFF
--- a/lib/nmatrix.rb
+++ b/lib/nmatrix.rb
@@ -27,11 +27,11 @@
 
 # For some reason nmatrix.so ends up in a different place during gem build.
 if File.exist? "lib/nmatrix/nmatrix.so"
-	# Development
-	require "nmatrix/nmatrix.so"
+  # Development
+  require "nmatrix/nmatrix.so"
 else
-	# Gem
-	require "nmatrix.so"
+  # Gem
+  require "nmatrix.so"
 end
 
 require 'nmatrix/nmatrix.rb'

--- a/lib/nmatrix/blas.rb
+++ b/lib/nmatrix/blas.rb
@@ -45,8 +45,8 @@ module NMatrix::BLAS
     #   - +c+ -> Matrix C.
     #   - +alpha+ -> A scalar value that multiplies A * B.
     #   - +beta+ -> A scalar value that multiplies C.
-    #   - +transpose_a+ -> 
-    #   - +transpose_b+ -> 
+    #   - +transpose_a+ ->
+    #   - +transpose_b+ ->
     #   - +m+ ->
     #   - +n+ ->
     #   - +k+ ->
@@ -61,48 +61,48 @@ module NMatrix::BLAS
     #   - +ArgumentError+ -> The dtype of the matrices must be equal.
     #
     def gemm(a, b, c = nil, alpha = 1.0, beta = 0.0, transpose_a = false, transpose_b = false, m = nil, n = nil, k = nil, lda = nil, ldb = nil, ldc = nil)
-    	raise ArgumentError, 'Expected dense NMatrices as first two arguments.' unless a.is_a?(NMatrix) and b.is_a?(NMatrix) and a.stype == :dense and b.stype == :dense
-    	raise ArgumentError, 'Expected nil or dense NMatrix as third argument.' unless c.nil? or (c.is_a?(NMatrix) and c.stype == :dense)
-    	raise ArgumentError, 'NMatrix dtype mismatch.'													unless a.dtype == b.dtype and (c ? a.dtype == c.dtype : true)
+      raise ArgumentError, 'Expected dense NMatrices as first two arguments.' unless a.is_a?(NMatrix) and b.is_a?(NMatrix) and a.stype == :dense and b.stype == :dense
+      raise ArgumentError, 'Expected nil or dense NMatrix as third argument.' unless c.nil? or (c.is_a?(NMatrix) and c.stype == :dense)
+      raise ArgumentError, 'NMatrix dtype mismatch.'													unless a.dtype == b.dtype and (c ? a.dtype == c.dtype : true)
 
-    	# First, set m, n, and k, which depend on whether we're taking the
-    	# transpose of a and b.
-    	if c
-    		m ||= c.shape[0]
-    		n ||= c.shape[1]
-    		k ||= transpose_a ? a.shape[0] : a.shape[1]
+      # First, set m, n, and k, which depend on whether we're taking the
+      # transpose of a and b.
+      if c
+        m ||= c.shape[0]
+        n ||= c.shape[1]
+        k ||= transpose_a ? a.shape[0] : a.shape[1]
 
-    	else
-    		if transpose_a
-    			# Either :transpose or :complex_conjugate.
-    			m ||= a.shape[1]
-    			k ||= a.shape[0]
+      else
+        if transpose_a
+          # Either :transpose or :complex_conjugate.
+          m ||= a.shape[1]
+          k ||= a.shape[0]
 
-    		else
-    			# No transpose.
-    			m ||= a.shape[0]
-    			k ||= a.shape[1]
-    		end
+        else
+          # No transpose.
+          m ||= a.shape[0]
+          k ||= a.shape[1]
+        end
 
-    		n ||= transpose_b ? b.shape[0] : b.shape[1]
-    		c		= NMatrix.new([m, n], a.dtype)
-    	end
+        n ||= transpose_b ? b.shape[0] : b.shape[1]
+        c		= NMatrix.new([m, n], a.dtype)
+      end
 
-    	# I think these are independent of whether or not a transpose occurs.
-    	lda ||= a.shape[1]
-    	ldb ||= b.shape[1]
-    	ldc ||= c.shape[1]
+      # I think these are independent of whether or not a transpose occurs.
+      lda ||= a.shape[1]
+      ldb ||= b.shape[1]
+      ldc ||= c.shape[1]
 
-    	# NM_COMPLEX64 and NM_COMPLEX128 both require complex alpha and beta.
-    	if a.dtype == :complex64 or a.dtype == :complex128
-    		alpha = Complex(1.0, 0.0) if alpha == 1.0
-    		beta  = Complex(0.0, 0.0) if beta  == 0.0
-    	end
+      # NM_COMPLEX64 and NM_COMPLEX128 both require complex alpha and beta.
+      if a.dtype == :complex64 or a.dtype == :complex128
+        alpha = Complex(1.0, 0.0) if alpha == 1.0
+        beta  = Complex(0.0, 0.0) if beta  == 0.0
+      end
 
-    	# For argument descriptions, see: http://www.netlib.org/blas/dgemm.f
-    	::NMatrix::BLAS.cblas_gemm(:row, transpose_a, transpose_b, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+      # For argument descriptions, see: http://www.netlib.org/blas/dgemm.f
+      ::NMatrix::BLAS.cblas_gemm(:row, transpose_a, transpose_b, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
 
-    	return c
+      return c
     end
 
     #
@@ -134,27 +134,27 @@ module NMatrix::BLAS
     #
     def gemv(a, x, y = nil, alpha = 1.0, beta = 0.0, transpose_a = false, m = nil, n = nil, lda = nil, incx = nil, incy = nil)
       raise ArgumentError, 'Expected dense NMatrices as first two arguments.' unless a.is_a?(NMatrix) and x.is_a?(NMatrix) and a.stype == :dense and x.stype == :dense
-     	raise ArgumentError, 'Expected nil or dense NMatrix as third argument.' unless y.nil? or (y.is_a?(NMatrix) and y.stype == :dense)
-     	raise ArgumentError, 'NMatrix dtype mismatch.'													unless a.dtype == x.dtype and (y ? a.dtype == y.dtype : true)
+      raise ArgumentError, 'Expected nil or dense NMatrix as third argument.' unless y.nil? or (y.is_a?(NMatrix) and y.stype == :dense)
+      raise ArgumentError, 'NMatrix dtype mismatch.'													unless a.dtype == x.dtype and (y ? a.dtype == y.dtype : true)
 
-    	m ||= transpose_a ? a.shape[1] : a.shape[0]
-    	n ||= transpose_a ? a.shape[0] : a.shape[1]
+      m ||= transpose_a ? a.shape[1] : a.shape[0]
+      n ||= transpose_a ? a.shape[0] : a.shape[1]
 
-    	lda		||= a.shape[1]
-    	incx	||= 1
-    	incy	||= 1
+      lda		||= a.shape[1]
+      incx	||= 1
+      incy	||= 1
 
-    	# NM_COMPLEX64 and NM_COMPLEX128 both require complex alpha and beta.
-    	if a.dtype == :complex64 or a.dtype == :complex128
-    		alpha = Complex(1.0, 0.0) if alpha == 1.0
-    		beta  = Complex(0.0, 0.0) if beta  == 0.0
+      # NM_COMPLEX64 and NM_COMPLEX128 both require complex alpha and beta.
+      if a.dtype == :complex64 or a.dtype == :complex128
+        alpha = Complex(1.0, 0.0) if alpha == 1.0
+        beta  = Complex(0.0, 0.0) if beta  == 0.0
       end
 
       y ||= NMatrix.new([m, n], a.dtype)
 
-    	::NMatrix::BLAS.cblas_gemv(transpose_a, m, n, alpha, a, lda, x, incx, beta, y, incy)
+      ::NMatrix::BLAS.cblas_gemv(transpose_a, m, n, alpha, a, lda, x, incx, beta, y, incy)
 
-    	return y
+      return y
     end
 
     #
@@ -164,13 +164,13 @@ module NMatrix::BLAS
     # Apply plane rotation.
     #
     # * *Arguments* :
-    #   - +x+ -> 
-    #   - +y+ -> 
-    #   - +s+ -> 
-    #   - +c+ -> 
-    #   - +incx+ -> 
-    #   - +incy+ -> 
-    #   - +n+ -> 
+    #   - +x+ ->
+    #   - +y+ ->
+    #   - +s+ ->
+    #   - +c+ ->
+    #   - +incx+ ->
+    #   - +incy+ ->
+    #   - +n+ ->
     # * *Returns* :
     #   - Array with the results, in the format [xx, yy]
     # * *Raises* :
@@ -180,7 +180,7 @@ module NMatrix::BLAS
     #
     def rot(x, y, c, s, incx = 1, incy = 1, n = nil)
       raise ArgumentError, 'Expected dense NMatrices as first two arguments.' unless x.is_a?(NMatrix) and y.is_a?(NMatrix) and x.stype == :dense and y.stype == :dense
-     	raise ArgumentError, 'NMatrix dtype mismatch.'													unless x.dtype == y.dtype
+      raise ArgumentError, 'NMatrix dtype mismatch.'													unless x.dtype == y.dtype
       raise ArgumentError, 'Need to supply n for non-standard incx, incy values' if n.nil? && incx != 1 && incx != -1 && incy != 1 && incy != -1
 
       n ||= x.size > y.size ? y.size : x.size

--- a/lib/nmatrix/io/market.rb
+++ b/lib/nmatrix/io/market.rb
@@ -29,21 +29,21 @@
 
 module NMatrix::IO::Market
   CONVERTER_AND_DTYPE = {
-      :real => [:to_f, :float64],
-      :complex => [:to_c, :complex128],
-      :integer => [:to_i, :int64],
-      :pattern => [:to_i, :byte]
+    :real => [:to_f, :float64],
+    :complex => [:to_c, :complex128],
+    :integer => [:to_i, :int64],
+    :pattern => [:to_i, :byte]
   }
 
   ENTRY_TYPE = {
-      :byte => :integer, :int8 => :integer, :int16 => :integer, :int32 => :integer, :int64 => :integer,
-      :float32 => :real, :float64 => :real, :complex64 => :complex, :complex128 => :complex
+    :byte => :integer, :int8 => :integer, :int16 => :integer, :int32 => :integer, :int64 => :integer,
+    :float32 => :real, :float64 => :real, :complex64 => :complex, :complex128 => :complex
   }
 
   class << self
     #
     # call-seq:
-    #     load(filename) -> 
+    #     load(filename) ->
     #
     # * *Arguments* :
     #   - +filename+ -> String with the filename to be saved.
@@ -89,7 +89,7 @@ module NMatrix::IO::Market
     #
     def save(matrix, filename, options = {})
       options = {:pattern => false,
-                 :symmetry => :general}.merge(options)
+        :symmetry => :general}.merge(options)
 
       mode = matrix.stype == :dense ? :array : :coordinate
       if [:rational32,:rational64,:rational128,:object].include?(matrix.dtype)
@@ -115,7 +115,7 @@ module NMatrix::IO::Market
     end
 
 
-  protected
+    protected
 
     def save_coordinate matrix, file, symmetry, pattern
       # Convert to a hash in order to store

--- a/lib/nmatrix/io/mat5_reader.rb
+++ b/lib/nmatrix/io/mat5_reader.rb
@@ -31,10 +31,10 @@ require_relative './mat_reader.rb'
 
 module NMatrix::IO::Matlab
   #
-	# Reader (and eventual writer) for a version 5 .mat file.
+  # Reader (and eventual writer) for a version 5 .mat file.
   #
-	class Mat5Reader < MatReader
-		attr_reader :file_header, :first_tag_field, :first_data_field
+  class Mat5Reader < MatReader
+    attr_reader :file_header, :first_tag_field, :first_data_field
 
     class Compressed
       include Packable
@@ -47,9 +47,9 @@ module NMatrix::IO::Matlab
       #     new(stream = nil, byte_order = nil, content_or_bytes = nil) -> Mat5Reader::Compressed
       #
       # * *Arguments* :
-      #   - ++ -> 
+      #   - ++ ->
       # * *Raises* :
-      #   - ++ -> 
+      #   - ++ ->
       #
       def initialize(stream = nil, byte_order = nil, content_or_bytes = nil)
         @stream			= stream
@@ -60,14 +60,14 @@ module NMatrix::IO::Matlab
 
         elsif content_or_bytes.is_a?(Fixnum)
           @padded_bytes = content_or_bytes
-        #else
-        #  raise ArgumentError, "Need a content string or a number of bytes; content_or_bytes is #{content_or_bytes.class.to_s}."
+          #else
+          #  raise ArgumentError, "Need a content string or a number of bytes; content_or_bytes is #{content_or_bytes.class.to_s}."
         end
       end
 
       #
       # call-seq:
-      #     compressed -> 
+      #     compressed ->
       #
       def compressed
         require "zlib"
@@ -77,7 +77,7 @@ module NMatrix::IO::Matlab
 
       #
       # call-seq:
-      #     content -> 
+      #     content ->
       #
       def content
         @content ||= extract
@@ -96,7 +96,7 @@ module NMatrix::IO::Matlab
       #     write_packed(packedio, options = {}) ->
       #
       # * *Arguments* :
-      #   - ++ -> 
+      #   - ++ ->
       # * *Returns* :
       #   -
       #
@@ -106,10 +106,10 @@ module NMatrix::IO::Matlab
 
       #
       # call-seq:
-      #     read_packed(packedio, options = {}) -> 
+      #     read_packed(packedio, options = {}) ->
       #
       # * *Arguments* :
-      #   - ++ -> 
+      #   - ++ ->
       # * *Returns* :
       #   -
       #
@@ -121,7 +121,7 @@ module NMatrix::IO::Matlab
       protected
       #
       # call-seq:
-      #     extract -> 
+      #     extract ->
       #
       def extract
         require 'zlib'
@@ -136,19 +136,19 @@ module NMatrix::IO::Matlab
     end
 
     MatrixDataStruct = Struct.new(
-      :cells, :logical, :global, :complex, :nonzero_max,
-      :matlab_class, :dimensions, :matlab_name, :real_part,
-      :imaginary_part, :row_index, :column_index)
+                                  :cells, :logical, :global, :complex, :nonzero_max,
+                                  :matlab_class, :dimensions, :matlab_name, :real_part,
+                                  :imaginary_part, :row_index, :column_index)
 
     class MatrixData < MatrixDataStruct
       include Packable
 
       #
       # call-seq:
-      #     write_packed(packedio, options) -> 
+      #     write_packed(packedio, options) ->
       #
       # * *Arguments* :
-      #   - ++ -> 
+      #   - ++ ->
       # * *Returns* :
       #   -
       #
@@ -200,7 +200,7 @@ module NMatrix::IO::Matlab
 
       #
       # call-seq:
-      #     unpacked_data(real_mdtype = nil, imag_mdtype = nil) -> 
+      #     unpacked_data(real_mdtype = nil, imag_mdtype = nil) ->
       #
       # Unpacks data without repacking it.
       #
@@ -230,7 +230,7 @@ module NMatrix::IO::Matlab
 
       #
       # call-seq:
-      #     repacked_data(to_dtype = nil) -> 
+      #     repacked_data(to_dtype = nil) ->
       #
       # Unpacks and repacks data into the appropriate format for NMatrix.
       #
@@ -360,10 +360,10 @@ module NMatrix::IO::Matlab
 
       #
       # call-seq:
-      #     read_packed(packedio, options) -> 
+      #     read_packed(packedio, options) ->
       #
       # * *Arguments* :
-      #   - ++ -> 
+      #   - ++ ->
       # * *Returns* :
       #   -
       #
@@ -424,7 +424,7 @@ module NMatrix::IO::Matlab
       #     ignore_padding(packedio, bytes) ->
       #
       # * *Arguments* :
-      #   - ++ -> 
+      #   - ++ ->
       # * *Returns* :
       #   -
       #
@@ -434,249 +434,249 @@ module NMatrix::IO::Matlab
     end
 
 
-		MDTYPE_UNPACK_ARGS =
-		MatReader::MDTYPE_UNPACK_ARGS.merge({
-			:miCOMPRESSED	=> [Compressed, {}],
-			:miMATRIX			=> [MatrixData, {}]
-		})
-		# include TaggedDataEnumerable
-		
-		FIRST_TAG_FIELD_POS = 128
-		
-		####################
-		# Instance Methods #
-		####################
+    MDTYPE_UNPACK_ARGS =
+      MatReader::MDTYPE_UNPACK_ARGS.merge({
+                                            :miCOMPRESSED	=> [Compressed, {}],
+                                            :miMATRIX			=> [MatrixData, {}]
+                                          })
+    # include TaggedDataEnumerable
 
-		def initialize(stream, options = {})
-			super(stream, options)
-			@file_header = seek_and_read_file_header
-		end
+    FIRST_TAG_FIELD_POS = 128
 
-		def to_a
-			returning(Array.new) do |ary|
-				self.each { |el| ary << el }
-			end
-		end
+    ####################
+    # Instance Methods #
+    ####################
 
-		def to_ruby
-			ary = self.to_a
-			
-			if ary.size == 1
-				ary.first.to_ruby 
-			else
-				ary.collect { |item| item.to_ruby }
-			end
-		end
+    def initialize(stream, options = {})
+      super(stream, options)
+      @file_header = seek_and_read_file_header
+    end
 
-		def guess_byte_order
-			stream.seek(Header::BYTE_ORDER_POS)
-			mi = stream.read(Header::BYTE_ORDER_LENGTH)
-			stream.seek(0)
-			mi == 'IM' ? :little : :big
-		end
+    def to_a
+      returning(Array.new) do |ary|
+        self.each { |el| ary << el }
+      end
+    end
 
-		def seek_and_read_file_header
-			stream.seek(0)
-			stream.read(FIRST_TAG_FIELD_POS).unpack(Header, {:endian => byte_order})
-		end
+    def to_ruby
+      ary = self.to_a
 
-		def each(&block)
-			stream.each(Element, {:endian => byte_order}) do |element|
-				if element.data.is_a?(Compressed)
-					StringIO.new(element.data.content, 'rb').each(Element, {:endian => byte_order}) do |compressed_element|
-						yield compressed_element.data
-					end
-					
-				else
-					yield element.data
-				end
-			end
-			
-			# Go back to the beginning in case we want to do it again.
-			stream.seek(FIRST_TAG_FIELD_POS)
-			
-			self
-		end
-		
-		####################
-		# Internal Classes #
-		####################
-		
-		class Header < Struct.new(:desc, :data_offset, :version, :endian)
+      if ary.size == 1
+        ary.first.to_ruby
+      else
+        ary.collect { |item| item.to_ruby }
+      end
+    end
 
-			include Packable
+    def guess_byte_order
+      stream.seek(Header::BYTE_ORDER_POS)
+      mi = stream.read(Header::BYTE_ORDER_LENGTH)
+      stream.seek(0)
+      mi == 'IM' ? :little : :big
+    end
 
-			BYTE_ORDER_LENGTH		= 2
-			DESC_LENGTH					= 116
-			DATA_OFFSET_LENGTH	= 8
-			VERSION_LENGTH			= 2
-			BYTE_ORDER_POS			= 126
+    def seek_and_read_file_header
+      stream.seek(0)
+      stream.read(FIRST_TAG_FIELD_POS).unpack(Header, {:endian => byte_order})
+    end
 
-			## TODO: TEST WRITE.
-			def write_packed(packedio, options)
-				packedio <<	[desc,				{:bytes => DESC_LENGTH				}] <<
-                    [data_offset,	{:bytes => DATA_OFFSET_LENGTH	}] <<
-                    [version,			{:bytes => VERSION_LENGTH			}] <<
-                    [byte_order,	{:bytes => BYTE_ORDER_LENGTH	}]
-			end
+    def each(&block)
+      stream.each(Element, {:endian => byte_order}) do |element|
+        if element.data.is_a?(Compressed)
+          StringIO.new(element.data.content, 'rb').each(Element, {:endian => byte_order}) do |compressed_element|
+            yield compressed_element.data
+          end
 
-			def read_packed(packedio, options)
-				self.desc, self.data_offset, self.version, self.endian = packedio >>
+        else
+          yield element.data
+        end
+      end
+
+      # Go back to the beginning in case we want to do it again.
+      stream.seek(FIRST_TAG_FIELD_POS)
+
+      self
+    end
+
+    ####################
+    # Internal Classes #
+    ####################
+
+    class Header < Struct.new(:desc, :data_offset, :version, :endian)
+
+      include Packable
+
+      BYTE_ORDER_LENGTH		= 2
+      DESC_LENGTH					= 116
+      DATA_OFFSET_LENGTH	= 8
+      VERSION_LENGTH			= 2
+      BYTE_ORDER_POS			= 126
+
+      ## TODO: TEST WRITE.
+      def write_packed(packedio, options)
+        packedio <<	[desc,				{:bytes => DESC_LENGTH				}] <<
+          [data_offset,	{:bytes => DATA_OFFSET_LENGTH	}] <<
+          [version,			{:bytes => VERSION_LENGTH			}] <<
+          [byte_order,	{:bytes => BYTE_ORDER_LENGTH	}]
+      end
+
+      def read_packed(packedio, options)
+        self.desc, self.data_offset, self.version, self.endian = packedio >>
           [String,	{:bytes => DESC_LENGTH																	}] >>
-					[String,	{:bytes => DATA_OFFSET_LENGTH														}] >>
-					[Integer,	{:bytes => VERSION_LENGTH, :endian => options[:endian]	}] >>
-					[String,	{:bytes => 2																						}]
-				
-				self.desc.strip!
-				self.data_offset.strip!
-				self.data_offset = nil if self.data_offset.empty?
-				
-				self.endian == 'IM' ? :little : :big
-			end
-		end
-		
-		class Tag < Struct.new(:data_type, :raw_data_type, :bytes, :small)
-			include Packable
-			
-			DATA_TYPE_OPTS = BYTES_OPTS = {:bytes => 4, :signed => false}
-			LENGTH = DATA_TYPE_OPTS[:bytes] + BYTES_OPTS[:bytes]
-			
-			## TODO: TEST WRITE.
-			def write_packed packedio, options
-				packedio << [data_type, DATA_TYPE_OPTS] << [bytes, BYTES_OPTS]
-			end
-			
-			def small?
-				self.bytes > 0 and self.bytes <= 4
-			end
-			
-			def size
-				small? ? 4 : 8
-			end
-			
-			def read_packed packedio, options
-				self.raw_data_type = packedio.read([Integer, DATA_TYPE_OPTS.merge(options)])
-				
-				# Borrowed from a SciPy patch
-				upper = self.raw_data_type >> 16
-				lower = self.raw_data_type & 0xFFFF
-				
-				if upper > 0
-					# Small data element format
-					raise IOError, 'Small data element format indicated, but length is more than 4 bytes!' if upper > 4
-					
-					self.bytes					= upper
-					self.raw_data_type	= lower
-					
-				else
-					self.bytes = packedio.read([Integer, BYTES_OPTS.merge(options)])
-				end
-				
-				self.data_type = MatReader::MDTYPES[self.raw_data_type]
-			end
+          [String,	{:bytes => DATA_OFFSET_LENGTH														}] >>
+          [Integer,	{:bytes => VERSION_LENGTH, :endian => options[:endian]	}] >>
+          [String,	{:bytes => 2																						}]
 
-			def inspect
-				"#<#{self.class.to_s} data_type=#{data_type}[#{raw_data_type}][#{raw_data_type.to_s(2)}] bytes=#{bytes} size=#{size}#{small? ? ' small' : ''}>"
-			end
-		end
+        self.desc.strip!
+        self.data_offset.strip!
+        self.data_offset = nil if self.data_offset.empty?
 
+        self.endian == 'IM' ? :little : :big
+      end
+    end
 
-		class ElementDataIOError < IOError
-			attr_reader :tag
-			
-			def initialize(tag = nil, msg = nil)
-				@tag = tag
-				super msg
-			end
+    class Tag < Struct.new(:data_type, :raw_data_type, :bytes, :small)
+      include Packable
 
-			def to_s
-				@tag.inspect + "\n" + super
-			end
-		end
+      DATA_TYPE_OPTS = BYTES_OPTS = {:bytes => 4, :signed => false}
+      LENGTH = DATA_TYPE_OPTS[:bytes] + BYTES_OPTS[:bytes]
+
+      ## TODO: TEST WRITE.
+      def write_packed packedio, options
+        packedio << [data_type, DATA_TYPE_OPTS] << [bytes, BYTES_OPTS]
+      end
+
+      def small?
+        self.bytes > 0 and self.bytes <= 4
+      end
+
+      def size
+        small? ? 4 : 8
+      end
+
+      def read_packed packedio, options
+        self.raw_data_type = packedio.read([Integer, DATA_TYPE_OPTS.merge(options)])
+
+        # Borrowed from a SciPy patch
+        upper = self.raw_data_type >> 16
+        lower = self.raw_data_type & 0xFFFF
+
+        if upper > 0
+          # Small data element format
+          raise IOError, 'Small data element format indicated, but length is more than 4 bytes!' if upper > 4
+
+          self.bytes					= upper
+          self.raw_data_type	= lower
+
+        else
+          self.bytes = packedio.read([Integer, BYTES_OPTS.merge(options)])
+        end
+
+        self.data_type = MatReader::MDTYPES[self.raw_data_type]
+      end
+
+      def inspect
+        "#<#{self.class.to_s} data_type=#{data_type}[#{raw_data_type}][#{raw_data_type.to_s(2)}] bytes=#{bytes} size=#{size}#{small? ? ' small' : ''}>"
+      end
+    end
 
 
-		class Element < Struct.new(:tag, :data)
-			include Packable
+    class ElementDataIOError < IOError
+      attr_reader :tag
 
-			def write_packed packedio, options
-				packedio << [tag, {}] << [data, {}]
-			end
+      def initialize(tag = nil, msg = nil)
+        @tag = tag
+        super msg
+      end
 
-			def read_packed(packedio, options)
-				raise(ArgumentError, 'Missing mandatory option :endian.') unless options.has_key?(:endian)
-				
-				tag = packedio.read([Tag, {:endian => options[:endian]}])
-				#STDERR.puts tag.inspect
-				data_type = MDTYPE_UNPACK_ARGS[tag.data_type]
-				
-				self.tag = tag
-				#STDERR.puts self.tag.inspect
-				
-				raise ElementDataIOError.new(tag, "Unrecognized Matlab type #{tag.raw_data_type}") if data_type.nil?
+      def to_s
+        @tag.inspect + "\n" + super
+      end
+    end
 
-				if tag.bytes == 0
-					self.data = []
-					
-				else
-					number_of_reads = data_type[1].has_key?(:bytes) ? tag.bytes / data_type[1][:bytes] : 1
-					data_type[1].merge!({:endian => options[:endian]})
 
-					if number_of_reads == 1
-						self.data = packedio.read(data_type)
-						
-					else
-						self.data =
-						returning(Array.new) do |ary|
-							number_of_reads.times { ary << packedio.read(data_type) }
-						end
-					end
-				
-					begin
-						ignore_padding(packedio, (tag.bytes + tag.size) % 8) unless [:miMATRIX, :miCOMPRESSED].include?(tag.data_type)
-						
-					rescue EOFError
-						STDERR.puts self.tag.inspect
-						raise(ElementDataIOError.new(tag, "Ignored too much"))
-					end
-				end
-			end
+    class Element < Struct.new(:tag, :data)
+      include Packable
 
-			def ignore_padding(packedio, bytes)
-				if bytes > 0
-					#STDERR.puts "Ignored #{8 - bytes} on #{self.tag.data_type}"
-					ignored = packedio.read(8 - bytes)
-					ignored_unpacked = ignored.unpack("C*")
-					raise(IOError, "Nonzero padding detected: #{ignored_unpacked}") if ignored_unpacked.any? { |i| i != 0 }
-				end
-			end
+      def write_packed packedio, options
+        packedio << [tag, {}] << [data, {}]
+      end
 
-			def to_ruby
-				data.to_ruby
-			end
-		end
+      def read_packed(packedio, options)
+        raise(ArgumentError, 'Missing mandatory option :endian.') unless options.has_key?(:endian)
 
-		# Doesn't unpack the contents of the element, e.g., if we want to handle
-		# manually, or pass the raw string of bytes into NMatrix.
-		class RawElement < Element
-			def read_packed(packedio, options)
-				raise(ArgumentError, 'Missing mandatory option :endian.') unless options.has_key?(:endian)
+        tag = packedio.read([Tag, {:endian => options[:endian]}])
+        #STDERR.puts tag.inspect
+        data_type = MDTYPE_UNPACK_ARGS[tag.data_type]
 
-				self.tag	= packedio.read([Tag,			{:endian => options[:endian]											}])
-				self.data	= packedio.read([String,	{:endian => options[:endian], :bytes => tag.bytes	}])
+        self.tag = tag
+        #STDERR.puts self.tag.inspect
 
-				begin
-					ignore_padding(packedio, (tag.bytes + tag.size) % 8) unless [:miMATRIX, :miCOMPRESSED].include?(tag.data_type)
-					
-				rescue EOFError
-					STDERR.puts self.tag.inspect
-					raise ElementDataIOError.new(tag, 'Ignored too much.')
-				end
-			end
-		end
-		
-		#####################
-		# End of Mat5Reader #
-		#####################
-		
-	end
+        raise ElementDataIOError.new(tag, "Unrecognized Matlab type #{tag.raw_data_type}") if data_type.nil?
+
+        if tag.bytes == 0
+          self.data = []
+
+        else
+          number_of_reads = data_type[1].has_key?(:bytes) ? tag.bytes / data_type[1][:bytes] : 1
+          data_type[1].merge!({:endian => options[:endian]})
+
+          if number_of_reads == 1
+            self.data = packedio.read(data_type)
+
+          else
+            self.data =
+              returning(Array.new) do |ary|
+              number_of_reads.times { ary << packedio.read(data_type) }
+            end
+          end
+
+          begin
+            ignore_padding(packedio, (tag.bytes + tag.size) % 8) unless [:miMATRIX, :miCOMPRESSED].include?(tag.data_type)
+
+          rescue EOFError
+            STDERR.puts self.tag.inspect
+            raise(ElementDataIOError.new(tag, "Ignored too much"))
+          end
+        end
+      end
+
+      def ignore_padding(packedio, bytes)
+        if bytes > 0
+          #STDERR.puts "Ignored #{8 - bytes} on #{self.tag.data_type}"
+          ignored = packedio.read(8 - bytes)
+          ignored_unpacked = ignored.unpack("C*")
+          raise(IOError, "Nonzero padding detected: #{ignored_unpacked}") if ignored_unpacked.any? { |i| i != 0 }
+        end
+      end
+
+      def to_ruby
+        data.to_ruby
+      end
+    end
+
+    # Doesn't unpack the contents of the element, e.g., if we want to handle
+    # manually, or pass the raw string of bytes into NMatrix.
+    class RawElement < Element
+      def read_packed(packedio, options)
+        raise(ArgumentError, 'Missing mandatory option :endian.') unless options.has_key?(:endian)
+
+        self.tag	= packedio.read([Tag,			{:endian => options[:endian]											}])
+        self.data	= packedio.read([String,	{:endian => options[:endian], :bytes => tag.bytes	}])
+
+        begin
+          ignore_padding(packedio, (tag.bytes + tag.size) % 8) unless [:miMATRIX, :miCOMPRESSED].include?(tag.data_type)
+
+        rescue EOFError
+          STDERR.puts self.tag.inspect
+          raise ElementDataIOError.new(tag, 'Ignored too much.')
+        end
+      end
+    end
+
+    #####################
+    # End of Mat5Reader #
+    #####################
+
+  end
 end

--- a/lib/nmatrix/io/mat_reader.rb
+++ b/lib/nmatrix/io/mat_reader.rb
@@ -31,59 +31,59 @@ require 'packable'
 
 module NMatrix::IO::Matlab
   #
-	# Class for parsing a .mat file stream.
-	#
-	# The full format of .mat files is available here:
-	# * http://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf
-	#
-	class MatReader
-		MDTYPE_UNPACK_ARGS = {
-			:miINT8		=> [Integer, {:signed			=> true,		:bytes => 1}],
-			:miUINT8	=> [Integer, {:signed			=> false,		:bytes => 1}],
-			:miINT16	=> [Integer, {:signed			=> true,		:bytes => 2}],
-			:miUINT16	=> [Integer, {:signed			=> false,		:bytes => 2}],
-			:miINT32	=> [Integer, {:signed			=> true,		:bytes => 4}],
-			:miUINT32	=> [Integer, {:signed			=> false,		:bytes => 4}],
-			:miSINGLE	=> [Float,   {:precision	=> :single,	:bytes => 4, :endian => :native}],
-			:miDOUBLE	=> [Float,   {:precision  => :double, :bytes => 4, :endian => :native}],
-			:miINT64	=> [Integer, {:signed			=> true,		:bytes => 8}],
-			:miUINT64	=> [Integer, {:signed			=> false,		:bytes => 8}]
-		}
+  # Class for parsing a .mat file stream.
+  #
+  # The full format of .mat files is available here:
+  # * http://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf
+  #
+  class MatReader
+    MDTYPE_UNPACK_ARGS = {
+      :miINT8		=> [Integer, {:signed			=> true,		:bytes => 1}],
+      :miUINT8	=> [Integer, {:signed			=> false,		:bytes => 1}],
+      :miINT16	=> [Integer, {:signed			=> true,		:bytes => 2}],
+      :miUINT16	=> [Integer, {:signed			=> false,		:bytes => 2}],
+      :miINT32	=> [Integer, {:signed			=> true,		:bytes => 4}],
+      :miUINT32	=> [Integer, {:signed			=> false,		:bytes => 4}],
+      :miSINGLE	=> [Float,   {:precision	=> :single,	:bytes => 4, :endian => :native}],
+      :miDOUBLE	=> [Float,   {:precision  => :double, :bytes => 4, :endian => :native}],
+      :miINT64	=> [Integer, {:signed			=> true,		:bytes => 8}],
+      :miUINT64	=> [Integer, {:signed			=> false,		:bytes => 8}]
+    }
 
-		DTYPE_PACK_ARGS = {
-			:byte				=> [Integer,	{:signed		=> false,		:bytes => 1}],
-			:int8				=> [Integer,	{:signed		=> true,		:bytes => 1}],
-			:int16			=> [Integer,	{:signed		=> true,		:bytes => 2}],
-			:int32			=> [Integer,	{:signed		=> true,		:bytes => 4}],
-			:int64			=> [Integer,	{:signed		=> true,		:bytes => 8}],
-			:float32		=> [Float,		{:precision	=> :single,	:bytes => 4, :endian => :native}],
-			:float64		=> [Float,		{:precision	=> :double,	:bytes => 8, :endian => :native}],
-			:complex64	=> [Float,		{:precision	=> :single,	:bytes => 4, :endian => :native}], #2x
-			:complex128	=> [Float,		{:precision	=> :double,	:bytes => 8, :endian => :native}]
-		}
+    DTYPE_PACK_ARGS = {
+      :byte				=> [Integer,	{:signed		=> false,		:bytes => 1}],
+      :int8				=> [Integer,	{:signed		=> true,		:bytes => 1}],
+      :int16			=> [Integer,	{:signed		=> true,		:bytes => 2}],
+      :int32			=> [Integer,	{:signed		=> true,		:bytes => 4}],
+      :int64			=> [Integer,	{:signed		=> true,		:bytes => 8}],
+      :float32		=> [Float,		{:precision	=> :single,	:bytes => 4, :endian => :native}],
+      :float64		=> [Float,		{:precision	=> :double,	:bytes => 8, :endian => :native}],
+      :complex64	=> [Float,		{:precision	=> :single,	:bytes => 4, :endian => :native}], #2x
+      :complex128	=> [Float,		{:precision	=> :double,	:bytes => 8, :endian => :native}]
+    }
 
     ITYPE_PACK_ARGS = {
       :uint8			=> [Integer,	{:signed		=> false,		:bytes => 1}],
-     	:uint16			=> [Integer,	{:signed		=> false,		:bytes => 2}],
-     	:uint32			=> [Integer,	{:signed		=> false,		:bytes => 4}],
-     	:uint64			=> [Integer,	{:signed		=> false,		:bytes => 8}],
+      :uint16			=> [Integer,	{:signed		=> false,		:bytes => 2}],
+      :uint32			=> [Integer,	{:signed		=> false,		:bytes => 4}],
+      :uint64			=> [Integer,	{:signed		=> false,		:bytes => 8}],
     }
 
-		NO_REPACK = [:miINT8, :miUINT8, :miINT16, :miINT32, :miSINGLE, :miDOUBLE, :miINT64]
+    NO_REPACK = [:miINT8, :miUINT8, :miINT16, :miINT32, :miSINGLE, :miDOUBLE, :miINT64]
 
-		# Convert from MATLAB dtype to NMatrix dtype.
-		MDTYPE_TO_DTYPE = {
-			:miUINT8	=> :byte,
-			:miINT8		=> :int8,
-			:miINT16	=> :int16,
-			:miUINT16	=> :int16,
-			:miINT32	=> :int32,
-			:miUINT32	=> :int32,
-			:miINT64	=> :int64,
-			:miUINT64	=> :int64,
-			:miSINGLE	=> :float32,
-			:miDOUBLE	=> :float64
-		}
+    # Convert from MATLAB dtype to NMatrix dtype.
+    MDTYPE_TO_DTYPE = {
+      :miUINT8	=> :byte,
+      :miINT8		=> :int8,
+      :miINT16	=> :int16,
+      :miUINT16	=> :int16,
+      :miINT32	=> :int32,
+      :miUINT32	=> :int32,
+      :miINT64	=> :int64,
+      :miUINT64	=> :int64,
+      :miSINGLE	=> :float32,
+      :miDOUBLE	=> :float64
+    }
 
     MDTYPE_TO_ITYPE = {
       :miUINT8 => :uint8,
@@ -96,56 +96,56 @@ module NMatrix::IO::Matlab
       :miUINT64	=> :uint64
     }
 
-		# Before release v7.1 (release 14) matlab (TM) used the system
-		# default character encoding scheme padded out to 16-bits. Release 14
-		# and later use Unicode. When saving character data, R14 checks if it
-		# can be encoded in 7-bit ascii, and saves in that format if so.
-		MDTYPES = [
-			nil,
-			:miINT8,
-			:miUINT8,
-			:miINT16,
-			:miUINT16,
-			:miINT32,
-			:miUINT32,
-			:miSINGLE,
-			nil,
-			:miDOUBLE,
-			nil,
-			nil,
-			:miINT64,
-			:miUINT64,
-			:miMATRIX,
-			:miCOMPRESSED,
-			:miUTF8,
-			:miUTF16,
-			:miUTF32
-		]
-		
-		MCLASSES = [
-			nil,
-			:mxCELL,
-			:mxSTRUCT,
-			:mxOBJECT,
-			:mxCHAR,
-			:mxSPARSE,
-			:mxDOUBLE,
-			:mxSINGLE,
-			:mxINT8,
-			:mxUINT8,
-			:mxINT16,
-			:mxUINT16,
-			:mxINT32,
-			:mxUINT32,
-			:mxINT64,
-			:mxUINT64,
-			:mxFUNCTION,
-			:mxOPAQUE,
-			:mxOBJECT_CLASS_FROM_MATRIX_H
-		]
+    # Before release v7.1 (release 14) matlab (TM) used the system
+    # default character encoding scheme padded out to 16-bits. Release 14
+    # and later use Unicode. When saving character data, R14 checks if it
+    # can be encoded in 7-bit ascii, and saves in that format if so.
+    MDTYPES = [
+               nil,
+               :miINT8,
+               :miUINT8,
+               :miINT16,
+               :miUINT16,
+               :miINT32,
+               :miUINT32,
+               :miSINGLE,
+               nil,
+               :miDOUBLE,
+               nil,
+               nil,
+               :miINT64,
+               :miUINT64,
+               :miMATRIX,
+               :miCOMPRESSED,
+               :miUTF8,
+               :miUTF16,
+               :miUTF32
+              ]
 
-		attr_reader :byte_order
-    
+    MCLASSES = [
+                nil,
+                :mxCELL,
+                :mxSTRUCT,
+                :mxOBJECT,
+                :mxCHAR,
+                :mxSPARSE,
+                :mxDOUBLE,
+                :mxSINGLE,
+                :mxINT8,
+                :mxUINT8,
+                :mxINT16,
+                :mxUINT16,
+                :mxINT32,
+                :mxUINT32,
+                :mxINT64,
+                :mxUINT64,
+                :mxFUNCTION,
+                :mxOPAQUE,
+                :mxOBJECT_CLASS_FROM_MATRIX_H
+               ]
+
+    attr_reader :byte_order
+
     #
     # call-seq:
     #     new(stream, options = {}) -> MatReader
@@ -153,24 +153,24 @@ module NMatrix::IO::Matlab
     # * *Raises* :
     #   - +ArgumentError+ -> First argument must be IO.
     #
-		def initialize(stream, options = {})
-			raise ArgumentError, 'First arg must be IO.' unless stream.is_a?(::IO)
+    def initialize(stream, options = {})
+      raise ArgumentError, 'First arg must be IO.' unless stream.is_a?(::IO)
 
-			@stream     = stream
-			@byte_order = options[:byte_order] || guess_byte_order
-		end
+      @stream     = stream
+      @byte_order = options[:byte_order] || guess_byte_order
+    end
 
     #
     # call-seq:
     #     guess_byte_order -> Symbol
     #
-		def guess_byte_order
-			# Assume native, since we don't know what type of file we have.
-			:native
-		end
+    def guess_byte_order
+      # Assume native, since we don't know what type of file we have.
+      :native
+    end
 
-		protected
+    protected
 
-      attr_reader :stream
-	end
+    attr_reader :stream
+  end
 end

--- a/lib/nmatrix/monkeys.rb
+++ b/lib/nmatrix/monkeys.rb
@@ -31,27 +31,27 @@
 #######################
 
 class Array
-	# Convert a Ruby Array to an NMatrix.
-	#
-	# You must provide a shape for the matrix as the first argument.
-	#
-	# == Arguments:
-	# <tt>shape</tt> :: Array describing matrix dimensions (or Fixnum for square) -- REQUIRED!
-	# <tt>dtype</tt> :: Override data type (e.g., to store a Float as :float32 instead of :float64) -- optional.
-	# <tt>stype</tt> :: Optional storage type (defaults to :dense)
-	def to_nm(shape, dtype = nil, stype = :dense)
-		dtype ||=
-		case self[0]
-		when Fixnum		then :int64
-		when Float		then :float64
-		when Rational	then :rational128
-		when Complex	then :complex128
-		end
-	
-		matrix = NMatrix.new(:dense, shape, self, dtype)
-	
-		if stype != :dense then matrix.cast(stype, dtype) else matrix end
-	end
+  # Convert a Ruby Array to an NMatrix.
+  #
+  # You must provide a shape for the matrix as the first argument.
+  #
+  # == Arguments:
+  # <tt>shape</tt> :: Array describing matrix dimensions (or Fixnum for square) -- REQUIRED!
+  # <tt>dtype</tt> :: Override data type (e.g., to store a Float as :float32 instead of :float64) -- optional.
+  # <tt>stype</tt> :: Optional storage type (defaults to :dense)
+  def to_nm(shape, dtype = nil, stype = :dense)
+    dtype ||=
+      case self[0]
+      when Fixnum		then :int64
+      when Float		then :float64
+      when Rational	then :rational128
+      when Complex	then :complex128
+      end
+
+    matrix = NMatrix.new(:dense, shape, self, dtype)
+
+    if stype != :dense then matrix.cast(stype, dtype) else matrix end
+  end
 
   unless method_defined?(:max)
     def max #:nodoc:
@@ -67,10 +67,10 @@ class Array
 end
 
 class Object #:nodoc:
-	def returning(value)
-		yield(value)
-		value
-	end
+  def returning(value)
+    yield(value)
+    value
+  end
 end
 
 class String #:nodoc:

--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -31,9 +31,9 @@ require_relative './shortcuts.rb'
 require_relative './lapack.rb'
 
 class NMatrix
-	# Read and write extensions for NMatrix. These are only loaded when needed.
+  # Read and write extensions for NMatrix. These are only loaded when needed.
   #
-	module IO
+  module IO
     module Matlab
       class << self
         def load_mat file_path
@@ -50,9 +50,9 @@ class NMatrix
     autoload :Market, 'nmatrix/io/market'
   end
 
-	# TODO: Make this actually pretty.
-	def pretty_print(q = nil) #:nodoc:
-		if dim != 2 || (dim == 2 && shape[1] > 10) # FIXME: Come up with a better way of restricting the display
+  # TODO: Make this actually pretty.
+  def pretty_print(q = nil) #:nodoc:
+    if dim != 2 || (dim == 2 && shape[1] > 10) # FIXME: Come up with a better way of restricting the display
       inspect
     else
 
@@ -60,10 +60,10 @@ class NMatrix
         ary = []
         (0...shape[1]).each do |j|
           o = begin
-            self[i, j]
-          rescue ArgumentError
-            nil
-          end
+                self[i, j]
+              rescue ArgumentError
+                nil
+              end
           ary << (o.nil? ? 'nil' : o)
         end
         ary.inspect
@@ -78,8 +78,8 @@ class NMatrix
       end
 
     end
-	end
-	alias :pp :pretty_print
+  end
+  alias :pp :pretty_print
 
   #
   # call-seq:
@@ -91,7 +91,7 @@ class NMatrix
   def rows
     shape[0]
   end
-  
+
   #
   # call-seq:
   #     cols -> Integer
@@ -229,35 +229,35 @@ class NMatrix
   #     complex_conjugate -> NMatrix
   #     complex_conjugate(new_stype) -> NMatrix
   #
-	# Get the complex conjugate of this matrix. See also complex_conjugate! for
-	# an in-place operation (provided the dtype is already +:complex64+ or
-	# +:complex128+).
-	#
-	# Doesn't work on list matrices, but you can optionally pass in the stype you
-	# want to cast to if you're dealing with a list matrix.
+  # Get the complex conjugate of this matrix. See also complex_conjugate! for
+  # an in-place operation (provided the dtype is already +:complex64+ or
+  # +:complex128+).
+  #
+  # Doesn't work on list matrices, but you can optionally pass in the stype you
+  # want to cast to if you're dealing with a list matrix.
   #
   # * *Arguments* :
   #   - +new_stype+ -> stype for the new matrix.
   # * *Returns* :
   #   - If the original NMatrix isn't complex, the result is a +:complex128+ NMatrix. Otherwise, it's the original dtype.
   #
-	def complex_conjugate(new_stype = self.stype)
-		self.cast(new_stype, NMatrix::upcast(dtype, :complex64)).complex_conjugate!
-	end
+  def complex_conjugate(new_stype = self.stype)
+    self.cast(new_stype, NMatrix::upcast(dtype, :complex64)).complex_conjugate!
+  end
 
   #
   # call-seq:
   #     conjugate_transpose -> NMatrix
   #
-	# Calculate the conjugate transpose of a matrix. If your dtype is already
-	# complex, this should only require one copy (for the transpose).
+  # Calculate the conjugate transpose of a matrix. If your dtype is already
+  # complex, this should only require one copy (for the transpose).
   #
   # * *Returns* :
   #   - The conjugate transpose of the matrix as a copy.
   #
-	def conjugate_transpose
-		self.transpose.complex_conjugate!
-	end
+  def conjugate_transpose
+    self.transpose.complex_conjugate!
+  end
 
   #
   # call-seq:
@@ -269,30 +269,30 @@ class NMatrix
   # * *Returns* :
   #   - True if +self+ is a hermitian matrix, nil otherwise.
   #
-	def hermitian?
-		return false if self.dim != 2 or self.shape[0] != self.shape[1]
-		
-		if [:complex64, :complex128].include?(self.dtype)
-			# TODO: Write much faster Hermitian test in C
-			self.eql?(self.conjugate_transpose)
-		else
-			symmetric?
-		end
-	end
+  def hermitian?
+    return false if self.dim != 2 or self.shape[0] != self.shape[1]
 
-	def inspect #:nodoc:
-		original_inspect = super()
-		original_inspect = original_inspect[0...original_inspect.size-1]
-		original_inspect + inspect_helper.join(" ") + ">"
-	end
+    if [:complex64, :complex128].include?(self.dtype)
+      # TODO: Write much faster Hermitian test in C
+      self.eql?(self.conjugate_transpose)
+    else
+      symmetric?
+    end
+  end
 
-	def __yale_ary__to_s(sym) #:nodoc:
-		ary = self.send("__yale_#{sym.to_s}__".to_sym)
-		
-		'[' + ary.collect { |a| a ? a : 'nil'}.join(',') + ']'
-	end
+  def inspect #:nodoc:
+    original_inspect = super()
+    original_inspect = original_inspect[0...original_inspect.size-1]
+    original_inspect + inspect_helper.join(" ") + ">"
+  end
 
-	class << self
+  def __yale_ary__to_s(sym) #:nodoc:
+    ary = self.send("__yale_#{sym.to_s}__".to_sym)
+
+    '[' + ary.collect { |a| a ? a : 'nil'}.join(',') + ']'
+  end
+
+  class << self
     #
     # call-seq:
     #     load_file(path) -> Mat5Reader
@@ -302,28 +302,28 @@ class NMatrix
     # * *Returns* :
     #   - A Mat5Reader object.
     #
-		def load_file(file_path)
-			NMatrix::IO::Mat5Reader.new(File.open(file_path, 'rb')).to_ruby
-		end
-	end
+    def load_file(file_path)
+      NMatrix::IO::Mat5Reader.new(File.open(file_path, 'rb')).to_ruby
+    end
+  end
 
-protected
-	def inspect_helper #:nodoc:
-		ary = []
-		ary << "shape:[#{shape.join(',')}]" << "dtype:#{dtype}" << "stype:#{stype}"
+  protected
+  def inspect_helper #:nodoc:
+    ary = []
+    ary << "shape:[#{shape.join(',')}]" << "dtype:#{dtype}" << "stype:#{stype}"
 
-		if stype == :yale
-			ary <<	"capacity:#{capacity}"
+    if stype == :yale
+      ary <<	"capacity:#{capacity}"
 
       # These are enabled by the DEBUG_YALE compiler flag in extconf.rb.
       if respond_to?(:__yale_a__)
         ary << "ija:#{__yale_ary__to_s(:ija)}" << "ia:#{__yale_ary__to_s(:ia)}" <<
-				  			"ja:#{__yale_ary__to_s(:ja)}" << "a:#{__yale_ary__to_s(:a)}" << "d:#{__yale_ary__to_s(:d)}" <<
-					  		"lu:#{__yale_ary__to_s(:lu)}" << "yale_size:#{__yale_size__}"
+          "ja:#{__yale_ary__to_s(:ja)}" << "a:#{__yale_ary__to_s(:a)}" << "d:#{__yale_ary__to_s(:d)}" <<
+          "lu:#{__yale_ary__to_s(:lu)}" << "yale_size:#{__yale_size__}"
       end
 
-		end
+    end
 
-		ary
-	end
+    ary
+  end
 end

--- a/lib/nmatrix/nvector.rb
+++ b/lib/nmatrix/nvector.rb
@@ -46,8 +46,8 @@ class NVector < NMatrix
   # * *Returns* :
   #   -
   #
-	def initialize(length, *args)
-		super(:dense, [length, 1], *args)
+  def initialize(length, *args)
+    super(:dense, [length, 1], *args)
     orientation
   end
 
@@ -55,12 +55,12 @@ class NVector < NMatrix
   # call-seq:
   #     orientation -> Symbol
   #
-	# Orientation defaults to column (e.g., [3,1] is a column of length 3). It
-	# may also be row, e.g., for [1,5].
+  # Orientation defaults to column (e.g., [3,1] is a column of length 3). It
+  # may also be row, e.g., for [1,5].
   #
-	def orientation
-		@orientation ||= :column
-	end
+  def orientation
+    @orientation ||= :column
+  end
 
   #
   # call-seq:
@@ -71,10 +71,10 @@ class NVector < NMatrix
   # * *Returns* :
   #   - NVector containing the transposed vector.
   #
-	def transpose
-		t = super()
+  def transpose
+    t = super()
     t.flip!
-	end
+  end
 
   #
   # call-seq:
@@ -85,14 +85,14 @@ class NVector < NMatrix
   # * *Returns* :
   #   - NVector containing the transposed vector.
   #
-	def transpose!
-		super()
-		self.flip!
-	end
+  def transpose!
+    super()
+    self.flip!
+  end
 
   #
   # call-seq:
-  #     multiply(m) -> 
+  #     multiply(m) ->
   #
   # ...
   #
@@ -101,10 +101,10 @@ class NVector < NMatrix
   # * *Returns* :
   #   -
   #
-	def multiply(m)
-		t = super(m)
+  def multiply(m)
+    t = super(m)
     t.flip!
-	end
+  end
 
   #
   # call-seq:
@@ -117,9 +117,9 @@ class NVector < NMatrix
   # * *Returns* :
   #   -
   #
-	def multiply!(m)
-		super().flip!
-	end
+  def multiply!(m)
+    super().flip!
+  end
 
   #
   # call-seq:
@@ -135,11 +135,11 @@ class NVector < NMatrix
   #   u[0] + u[1]       # => 30
   #   u[0 .. 1].shape   # => [2, 1]
   #
-	def [](i)
-		case @orientation
-		when :column;	super(i, 0)
-		when :row;	  super(0, i)
-		end
+  def [](i)
+    case @orientation
+    when :column;	super(i, 0)
+    when :row;	  super(0, i)
+    end
   end
 
   #
@@ -148,12 +148,12 @@ class NVector < NMatrix
   #
   # Stores +value+ at position +index+.
   #
-	def []=(i, val)
-		case @orientation
-		when :column;	super(i, 0, val)
-		when :row;	  super(0, i, val)
-		end
-	end
+  def []=(i, val)
+    case @orientation
+    when :column;	super(i, 0, val)
+    when :row;	  super(0, i, val)
+    end
+  end
 
   #
   # call-seq:
@@ -161,25 +161,25 @@ class NVector < NMatrix
   #
   # Returns the dimension of a vector, which is 1.
   #
-	def dim; 1; end
+  def dim; 1; end
 
   # shorthand for the dominant shape component
   def size
     shape[0] > 1 ? shape[0] : shape[1]
   end
 
-	# TODO: Make this actually pretty.
-	def pretty_print #:nodoc:
-		dim = @orientation == :row ? 1 : 0
-		
-		puts (0...shape[dim]).inject(Array.new) { |a, i| a << self[i] }.join('  ')
-	end
+  # TODO: Make this actually pretty.
+  def pretty_print #:nodoc:
+    dim = @orientation == :row ? 1 : 0
 
-protected
-	def inspect_helper #:nodoc:
-		super() << "orientation:#{self.orientation}"
-	end
-	
+    puts (0...shape[dim]).inject(Array.new) { |a, i| a << self[i] }.join('  ')
+  end
+
+  protected
+  def inspect_helper #:nodoc:
+    super() << "orientation:#{self.orientation}"
+  end
+
   #
   # call-seq:
   #     flip_orientation! -> NVector
@@ -189,8 +189,8 @@ protected
   # * *Returns* :
   #   - NVector with orientation changed.
   #
-	def flip_orientation!
-		returning(self) { @orientation = @orientation == :row ? :column : :row }
-	end
-	alias :flip! :flip_orientation!
+  def flip_orientation!
+    returning(self) { @orientation = @orientation == :row ? :column : :row }
+  end
+  alias :flip! :flip_orientation!
 end

--- a/lib/nmatrix/shortcuts.rb
+++ b/lib/nmatrix/shortcuts.rb
@@ -38,8 +38,8 @@ class NMatrix
     #
     # call-seq:
     #    zeros(size) -> NMatrix
-    #    zeros(size, dtype) -> NMatrix    
-    #    zeros(stype, size, dtype) -> NMatrix 
+    #    zeros(size, dtype) -> NMatrix
+    #    zeros(stype, size, dtype) -> NMatrix
     #
     # Creates a new matrix of zeros with the dimensions supplied as
     # parameters.
@@ -53,14 +53,14 @@ class NMatrix
     #
     # Examples:
     #
-    #   NMatrix.zeros(2) # =>  0.0   0.0   
+    #   NMatrix.zeros(2) # =>  0.0   0.0
     #                          0.0   0.0
     #
     #   NMatrix.zeros([2, 3], :int32) # =>  0  0  0
     #                                       0  0  0
     #
     #   NMatrix.zeros(:list, [1, 5], :int32) # =>  0  0  0  0  0
-    #    
+    #
     def zeros(*params)
       dtype = params.last.is_a?(Symbol) ? params.pop : :float64
       stype = params.first.is_a?(Symbol) ? params.shift : :dense
@@ -101,7 +101,7 @@ class NMatrix
     # call-seq:
     #     eye(size) -> NMatrix
     #     eye(size, dtype) -> NMatrix
-    #     eye(stype, size, dtype) -> NMatrix    
+    #     eye(stype, size, dtype) -> NMatrix
     #
     # Creates an identity matrix (square matrix rank 2).
     #
@@ -130,13 +130,13 @@ class NMatrix
       stype = params.first.is_a?(Symbol) ? params.shift : :dense
 
       dim = params.first
-      
+
       # Fill the diagonal with 1's.
       m = NMatrix.zeros(stype, dim, dtype)
-      (0 .. (dim - 1)).each do |i| 
+      (0 .. (dim - 1)).each do |i|
         m[i, i] = 1
       end
-      
+
       m
     end
     alias :identity :eye
@@ -162,7 +162,7 @@ class NMatrix
       rng = Random.new
 
       random_values = []
-      
+
       # Construct the values of the final matrix based on the dimension.
       if size.is_a?(Integer)
         (size * size - 1).times { |i| random_values << rng.rand }
@@ -200,14 +200,14 @@ class NMatrix
     def seq(*params)
       dtype = params.last.is_a?(Symbol) ? params.pop : nil
       size = params.first
-      
+
       # Must provide the dimension as an Integer for a square matrix or as an
       # 2 element array, e.g. [2,4].
       unless size.is_a?(Integer) || (size.is_a?(Array) && size.size < 3)
         raise ArgumentError, "seq() accepts only integers or 2-element arrays \
 as dimension."
       end
-      
+
       # Construct the values of the final matrix based on the dimension.
       if size.is_a?(Integer)
         values = (0 .. (size * size - 1)).to_a
@@ -215,7 +215,7 @@ as dimension."
         # Dimensions given by a 2 element array.
         values = (0 .. (size.first * size.last - 1)).to_a
       end
-      
+
       # It'll produce :int32, except if a dtype is provided.
       NMatrix.new(:dense, size, values, dtype)
     end
@@ -279,7 +279,7 @@ as dimension."
     def cindgen(size)
       NMatrix.seq(size, :complex64)
     end
-  
+
   end
 
   #
@@ -299,7 +299,7 @@ as dimension."
   #
   #   m = NMatrix.new(2, [1, 4, 9, 14], :int32) # =>  1   4
   #                                                   9  14
-  #   
+  #
   #   m.column(1) # =>   4
   #                     14
   #
@@ -307,7 +307,7 @@ as dimension."
     unless [:copy, :reference].include?(get_by)
       raise ArgumentError, "column() 2nd parameter must be :copy or :reference"
     end
-    
+
     if get_by == :copy
       self.slice(0 ... self.shape[0], column_number)
     else # by reference
@@ -316,7 +316,7 @@ as dimension."
   end
 
   alias :col :column
-  
+
   #
   # call-seq:
   #     row(row_number) -> NMatrix
@@ -332,17 +332,17 @@ as dimension."
     unless [:copy, :reference].include?(get_by)
       raise ArgumentError, "row() 2nd parameter must be :copy or :reference"
     end
-    
+
     if get_by == :copy
       self.slice(row_number, 0 ... self.shape[1])
     else # by reference
       self[row_number, 0 ... self.shape[1]]
-    end    
+    end
   end
 end
 
 class NVector < NMatrix
-  
+
   class << self
     #
     # call-seq:
@@ -361,7 +361,7 @@ class NVector < NMatrix
     # Examples:
     #
     #   NVector.zeros(2) # =>  0.0
-    #                          0.0   
+    #                          0.0
     #
     #   NVector.zeros(3, :int32) # =>  0
     #                                  0
@@ -389,7 +389,7 @@ class NVector < NMatrix
     # Examples:
     #
     #   NVector.ones(2) # =>  1.0
-    #                         1.0   
+    #                         1.0
     #
     #   NVector.ones(3, :int32) # =>  1
     #                                 1
@@ -422,7 +422,7 @@ class NVector < NMatrix
 
       random_values = []
       size.times { |i| random_values << rng.rand }
-      
+
       NVector.new(size, random_values, :float64)
     end
 
@@ -453,9 +453,9 @@ class NVector < NMatrix
       unless n.is_a?(Integer)
         raise ArgumentError, "NVector::seq() only accepts integers as size."
       end
-            
+
       values = (0 ... n).to_a
-      
+
       NVector.new(n, values, dtype)
     end
 
@@ -540,7 +540,7 @@ class NVector < NMatrix
     # Example:
     #   x = NVector.linspace(0, Math::PI, 1000)
     #   => #<NMatrix:0x007f83921992f0shape:[1000,1] dtype:float64 stype:dense>
-    #   
+    #
     #   x.pp
     #     [0.0]
     #     [0.0031447373909807737]
@@ -549,15 +549,15 @@ class NVector < NMatrix
     #     [3.135303178807831]
     #     [3.138447916198812]
     #     [3.141592653589793]
-    #   => nil 
+    #   => nil
     #
     def linspace(a, b, n = 100)
       # See: http://www.mathworks.com/help/matlab/ref/linspace.html
       # Formula:  seq(n) * step + a
-      
+
       # step = ((b - a) / (n - 1))
       step = (b - a) * (1.0 / (n - 1))
-      
+
       # dtype = :float64 is used to prevent integer coercion.
       result = NVector.seq(n, :float64) * NVector.new(n, step, :float64)
       result += NVector.new(n, a, :float64)


### PR DESCRIPTION
This just removes all trailing whitespace and normalizes indentation to 2-space indent.

Line length, argument alignment, other forms of formatting aren't modified.
