### PR TITLE
Cleanup whitespace in spec/ and ext/

### DIFF
--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -63,19 +63,19 @@ end
 def create_conf_h(file) #:nodoc:
   print "creating #{file}\n"
   File.open(file, 'w') do |hfile|
-  	header_guard = file.upcase.sub(/\s|\./, '_')
-		
-		hfile.puts "#ifndef #{header_guard}"
-		hfile.puts "#define #{header_guard}"
-		hfile.puts
-		
-		for line in $defs
-		  line =~ /^-D(.*)/
-		  hfile.printf "#define %s 1\n", $1
-		end
-		
-		hfile.puts
-		hfile.puts "#endif"
+    header_guard = file.upcase.sub(/\s|\./, '_')
+
+    hfile.puts "#ifndef #{header_guard}"
+    hfile.puts "#define #{header_guard}"
+    hfile.puts
+
+    for line in $defs
+      line =~ /^-D(.*)/
+      hfile.printf "#define %s 1\n", $1
+    end
+
+    hfile.puts
+    hfile.puts "#endif"
   end
 end
 
@@ -84,7 +84,7 @@ if RUBY_VERSION < '1.9'
 else
   $INSTALLFILES = [['nmatrix.h', '$(archdir)'], ['nmatrix.hpp', '$(archdir)'], ['nmatrix_config.h', '$(archdir)']]
   if /cygwin|mingw/ =~ RUBY_PLATFORM
-	 $INSTALLFILES << ['libnmatrix.a', '$(archdir)']
+    $INSTALLFILES << ['libnmatrix.a', '$(archdir)']
   end
 end
 
@@ -96,19 +96,19 @@ $DEBUG = true
 $CFLAGS = ["-Wall ",$CFLAGS].join(" ")
 
 $srcs = [
-	'nmatrix.cpp',
-	'ruby_constants.cpp',
+         'nmatrix.cpp',
+         'ruby_constants.cpp',
 
-	'data/data.cpp',
-	'util/math.cpp',
-  'util/sl_list.cpp',
-  'util/io.cpp',
-  'storage/common.cpp',
-	'storage/storage.cpp',
-	'storage/dense.cpp',
-  'storage/yale.cpp',
-  'storage/list.cpp'
-]
+         'data/data.cpp',
+         'util/math.cpp',
+         'util/sl_list.cpp',
+         'util/io.cpp',
+         'storage/common.cpp',
+         'storage/storage.cpp',
+         'storage/dense.cpp',
+         'storage/yale.cpp',
+         'storage/list.cpp'
+        ]
 # add smmp in to get generic transp; remove smmp2 to eliminate funcptr transp
 
 # The next line allows the user to supply --with-atlas-dir=/usr/local/atlas,
@@ -174,10 +174,10 @@ end
 
 
 if CONFIG['CXX'] == 'clang++'
-	$CPP_STANDARD = 'c++11'
+  $CPP_STANDARD = 'c++11'
 
 else
-	version = gplusplus_version
+  version = gplusplus_version
   if version < '4.3.0' && CONFIG['CXX'] == 'g++'  # see if we can find a newer G++, unless it's been overridden by user
     if !find_newer_gplusplus
       raise("You need a version of g++ which supports -std=c++0x or -std=c++11. If you're on a Mac and using Homebrew, we recommend using mac-brew-gcc.sh to install a more recent g++.")
@@ -185,11 +185,11 @@ else
     version = gplusplus_version
   end
 
-	if version < '4.7.0'
-		$CPP_STANDARD = 'c++0x'
-	else
-		$CPP_STANDARD = 'c++11'
-	end
+  if version < '4.7.0'
+    $CPP_STANDARD = 'c++0x'
+  else
+    $CPP_STANDARD = 'c++11'
+  end
 end
 
 # For release, these next two should both be changed to -O3.

--- a/ext/nmatrix/new_extconf.rb
+++ b/ext/nmatrix/new_extconf.rb
@@ -31,26 +31,25 @@ $CFLAGS							= '-I. -fPIC -Wall -pipe -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fst
 CONFIG['CXXFLAGS']	= '-std=c++11'
 
 if clang_path = find_executable('clang') and clang_pp_path = find_executable('clang++')
-	CONFIG['CC']	= clang_path
-	CONFIG['CXX']	= clang_pp_path
+  CONFIG['CC']	= clang_path
+  CONFIG['CXX']	= clang_pp_path
 end
 
 # Necessary header files.
-find_header('ruby/config.h') 
+find_header('ruby/config.h')
 
 # List the source files that need to be compiled.
 $srcs = [
-#	'nmatrix.cpp',
-	'ruby_constants.cpp',
-	
-	'data/data.cpp',
-	'math.cpp',
-	'storage/storage.cpp',
-	'storage/dense.cpp'
-]
+         #	'nmatrix.cpp',
+         'ruby_constants.cpp',
+
+         'data/data.cpp',
+         'math.cpp',
+         'storage/storage.cpp',
+         'storage/dense.cpp'
+        ]
 
 $objs = $srcs.map { |f| f.sub('.cpp', '.o') }
 
 # Create the actual Makefile.
 create_makefile('NMatrix')
-

--- a/ext/nmatrix/ttable_helper.rb
+++ b/ext/nmatrix/ttable_helper.rb
@@ -3,124 +3,124 @@
 # A helper file for generating and maintaining template tables.
 
 def nullify(disabled) #:nodoc:
-	DTYPES.map { |t| if disabled.include?(t) then :NULL else t end }
+  DTYPES.map { |t| if disabled.include?(t) then :NULL else t end }
 end
 
 DTYPES = [
-	:uint8_t,
-	:int8_t,
-	:int16_t,
-	:int32_t,
-	:int64_t,
-	:float32_t,
-	:float64_t,
-	:'nm::Complex64',
-	:'nm::Complex128',
-	:'nm::Rational32',
-	:'nm::Rational64',
-	:'nm::Rational128',
-	:'nm::RubyObject'
-]
+          :uint8_t,
+          :int8_t,
+          :int16_t,
+          :int32_t,
+          :int64_t,
+          :float32_t,
+          :float64_t,
+          :'nm::Complex64',
+          :'nm::Complex128',
+          :'nm::Rational32',
+          :'nm::Rational64',
+          :'nm::Rational128',
+          :'nm::RubyObject'
+         ]
 
 ITYPES = [
-	:uint8_t,
-	:uint16_t,
-	:uint32_t,
-	:uint64_t
-]
+          :uint8_t,
+          :uint16_t,
+          :uint32_t,
+          :uint64_t
+         ]
 
 EWOPS = [
-	:'nm::EW_ADD',
-	:'nm::EW_SUB',
-	:'nm::EW_MUL',
-	:'nm::EW_DIV',
-	:'nm::EW_MOD',
-  :'nm::EW_EQEQ',
-  :'nm::EW_NEQ',
-  :'nm::EW_LT',
-  :'nm::EW_GT',
-  :'nm::EW_LEQ',
-  :'nm::EW_GEQ'
-]
+         :'nm::EW_ADD',
+         :'nm::EW_SUB',
+         :'nm::EW_MUL',
+         :'nm::EW_DIV',
+         :'nm::EW_MOD',
+         :'nm::EW_EQEQ',
+         :'nm::EW_NEQ',
+         :'nm::EW_LT',
+         :'nm::EW_GT',
+         :'nm::EW_LEQ',
+         :'nm::EW_GEQ'
+        ]
 
 LR_ALLOWED = {
-	:uint8_t	 		=> nullify([:RubyObject]),
-	:int8_t				=> nullify([:RubyObject]),
-	:int16_t			=> nullify([:RubyObject]),
-	:int32_t			=> nullify([:RubyObject]),
-	:int64_t			=> nullify([:RubyObject]),
-	:float32_t		=> nullify([:RubyObject]),
-	:float64_t		=> nullify([:RubyObject]),
-	:Complex64		=> nullify([:RubyObject]),
-	:Complex128		=> nullify([:RubyObject]),
-	:Rational32		=> nullify([:float32_t, :float64_t, :'nm::Complex64', :'nm::Complex128', :'nm::RubyObject']),
-	:Rational64		=> nullify([:float32_t, :float64_t, :'nm::Complex64', :'nm::Complex128', :'nm::RubyObject']),
-	:Rational128	=> nullify([:float32_t, :float64_t, :'nm::Complex64', :'nm::Complex128', :'nm::RubyObject']),
-	:RubyObject		=> nullify(DTYPES - [:RubyObject])
+  :uint8_t	 		=> nullify([:RubyObject]),
+  :int8_t				=> nullify([:RubyObject]),
+  :int16_t			=> nullify([:RubyObject]),
+  :int32_t			=> nullify([:RubyObject]),
+  :int64_t			=> nullify([:RubyObject]),
+  :float32_t		=> nullify([:RubyObject]),
+  :float64_t		=> nullify([:RubyObject]),
+  :Complex64		=> nullify([:RubyObject]),
+  :Complex128		=> nullify([:RubyObject]),
+  :Rational32		=> nullify([:float32_t, :float64_t, :'nm::Complex64', :'nm::Complex128', :'nm::RubyObject']),
+  :Rational64		=> nullify([:float32_t, :float64_t, :'nm::Complex64', :'nm::Complex128', :'nm::RubyObject']),
+  :Rational128	=> nullify([:float32_t, :float64_t, :'nm::Complex64', :'nm::Complex128', :'nm::RubyObject']),
+  :RubyObject		=> nullify(DTYPES - [:RubyObject])
 }
 
 lines =
-case ARGV[0]
-when 'OPLR'
-	'{' +
-	EWOPS.map do |op|
-	
-		'{' +
-		DTYPES.map do |l_dtype|
-		
-			'{' +
-			LR_ALLOWED[l_dtype].map do |r_dtype|
-				if r_dtype == :NULL
-					'NULL'
-				else
-					"fun<#{op}, #{l_dtype}, #{r_dtype}>"
-				end
-			end.join(', ') +
-			'}'
-		
-		end.join(",\n") +
-		'}'
-	
-	end.join(",\n") +
-	'}'
+  case ARGV[0]
+  when 'OPLR'
+    '{' +
+      EWOPS.map do |op|
 
-when 'OPID'
-	'{' +
-	EWOPS.map do |op|
-		'{' +
-		ITYPES.map do |itype|
-			'{' +
-			DTYPES.map do |dtype|
-			
-				if dtype == :NULL
-					'NULL'
-				else
-					"fun<#{op}, #{itype}, #{dtype}>"
-				end
-		
-			end.join(",") +
-			'}'
-		end.join(",\\\n") +
-		'}'
-	end.join(",\\\n") +
-	'}'
+    '{' +
+      DTYPES.map do |l_dtype|
 
-when 'LR'
-	'{' +
-		DTYPES.map do |l_dtype|
-		
-			'{' +
-			LR_ALLOWED[l_dtype].map do |r_dtype|
-				if r_dtype == :NULL
-					'NULL'
-				else
-					"fun<#{l_dtype}, #{r_dtype}>"
-				end
-			end.join(', ') +
-			'}'
-		
-		end.join(",\n") +
-		'}'
-end
+      '{' +
+        LR_ALLOWED[l_dtype].map do |r_dtype|
+        if r_dtype == :NULL
+          'NULL'
+        else
+          "fun<#{op}, #{l_dtype}, #{r_dtype}>"
+        end
+      end.join(', ') +
+        '}'
+
+    end.join(",\n") +
+      '}'
+
+  end.join(",\n") +
+      '}'
+
+  when 'OPID'
+    '{' +
+      EWOPS.map do |op|
+    '{' +
+      ITYPES.map do |itype|
+      '{' +
+        DTYPES.map do |dtype|
+
+        if dtype == :NULL
+          'NULL'
+        else
+          "fun<#{op}, #{itype}, #{dtype}>"
+        end
+
+      end.join(",") +
+        '}'
+    end.join(",\\\n") +
+      '}'
+  end.join(",\\\n") +
+      '}'
+
+  when 'LR'
+    '{' +
+      DTYPES.map do |l_dtype|
+
+    '{' +
+      LR_ALLOWED[l_dtype].map do |r_dtype|
+      if r_dtype == :NULL
+        'NULL'
+      else
+        "fun<#{l_dtype}, #{r_dtype}>"
+      end
+    end.join(', ') +
+      '}'
+
+  end.join(",\n") +
+      '}'
+  end
 
 puts lines

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -56,7 +56,7 @@ describe "math" do
     end
   end
 
-   # TODO: Get it working with ROBJ too
+  # TODO: Get it working with ROBJ too
   [:byte,:int8,:int16,:int32,:int64,:float32,:float64,:rational64,:rational128].each do |left_dtype|
     [:byte,:int8,:int16,:int32,:int64,:float32,:float64,:rational64,:rational128].each do |right_dtype|
 

--- a/spec/nmatrix_list_spec.rb
+++ b/spec/nmatrix_list_spec.rb
@@ -28,68 +28,68 @@ require "./lib/nmatrix"
 
 describe NMatrix do
   context :list do
-  it "should compare with ==" do
-    n = NMatrix.new(:list, [3,3,3], :int64)
-    m = NMatrix.new(:list, [3,3,3], :int64)
-    n.should == m
-    n[0,0,0] = 5
-    n.should_not == m
-    n[0,0,1] = 52
-    n[1,2,1] = -4
+    it "should compare with ==" do
+      n = NMatrix.new(:list, [3,3,3], :int64)
+      m = NMatrix.new(:list, [3,3,3], :int64)
+      n.should == m
+      n[0,0,0] = 5
+      n.should_not == m
+      n[0,0,1] = 52
+      n[1,2,1] = -4
 
-    m[0,0,0] = 5
-    m[0,0,1] = 52
-    m[1,2,1] = -4
-    n.should == m
-  end
+      m[0,0,0] = 5
+      m[0,0,1] = 52
+      m[1,2,1] = -4
+      n.should == m
+    end
 
-  it "should handle missing default value" do
-    NMatrix.new(:list, 3, :int8)[0,0].should    == 0
-    NMatrix.new(:list, 4, :float64)[0,0].should == 0.0
-  end
+    it "should handle missing default value" do
+      NMatrix.new(:list, 3, :int8)[0,0].should    == 0
+      NMatrix.new(:list, 4, :float64)[0,0].should == 0.0
+    end
 
-  it "should allow conversion to a Ruby Hash" do
-    n = NMatrix.new(:list, 3, 1, :int64)
-    n[0,1] = 50
-    h = n.to_h
-    h.size.should == 1
-    h[0].size.should == 1
-    h[0][1].should == 50
-    h[0][2].should == 1
-    h[1][0].should == 1
-  end
+    it "should allow conversion to a Ruby Hash" do
+      n = NMatrix.new(:list, 3, 1, :int64)
+      n[0,1] = 50
+      h = n.to_h
+      h.size.should == 1
+      h[0].size.should == 1
+      h[0][1].should == 50
+      h[0][2].should == 1
+      h[1][0].should == 1
+    end
 
 
-  ##TODO: Make this test better. It's not nearly exhaustive enough as is.
-  it "should handle recursive removal" do
-    n = NMatrix.new(:list, [3,3,3], 0)
-    n[0,0,0] = 2
-    n[1,1,1] = 1
-    n[1,0,0] = 3
-    n[0,0,1] = 4
+    ##TODO: Make this test better. It's not nearly exhaustive enough as is.
+    it "should handle recursive removal" do
+      n = NMatrix.new(:list, [3,3,3], 0)
+      n[0,0,0] = 2
+      n[1,1,1] = 1
+      n[1,0,0] = 3
+      n[0,0,1] = 4
 
-    n[0,0,0].should == 2
-    n[1,1,1].should == 1
-    n[1,0,0].should == 3
-    n[0,0,1].should == 4
+      n[0,0,0].should == 2
+      n[1,1,1].should == 1
+      n[1,0,0].should == 3
+      n[0,0,1].should == 4
 
-    n[1,1,1] = 0
-    n[0,0,0].should == 2
-    n[1,1,1].should == 0
-    n[1,0,0].should == 3
-    n[0,0,1].should == 4
-  end
+      n[1,1,1] = 0
+      n[0,0,0].should == 2
+      n[1,1,1].should == 0
+      n[1,0,0].should == 3
+      n[0,0,1].should == 4
+    end
 
-  it "should correctly insert a value between the middle and last entries of a three-element list" do
-    n = NMatrix.new(:list, 5940, 0, :float64)
-    n[0,0] = -7.0710685196786e-01
-    n[330,0] = 7.0710685196786e-01
-    n[1,0] = -7.0710685196786e-01
-    n[2,0] = -7.0710685196786e-01
-    n[0,0].should_not == 0
-    n[330,0].should_not == 0
-    n[2,0].should_not == 0
-    n[1,0].should_not == 0
-  end
+    it "should correctly insert a value between the middle and last entries of a three-element list" do
+      n = NMatrix.new(:list, 5940, 0, :float64)
+      n[0,0] = -7.0710685196786e-01
+      n[330,0] = 7.0710685196786e-01
+      n[1,0] = -7.0710685196786e-01
+      n[2,0] = -7.0710685196786e-01
+      n[0,0].should_not == 0
+      n[330,0].should_not == 0
+      n[2,0].should_not == 0
+      n[1,0].should_not == 0
+    end
   end
 end

--- a/spec/nmatrix_spec.rb
+++ b/spec/nmatrix_spec.rb
@@ -42,14 +42,14 @@ describe NMatrix do
 
   it "allows stype casting of a dim 2 matrix between dense, sparse, and list (different dtypes)" do
     m = NMatrix.new(:dense, [3,3], [0,0,1,0,2,0,3,4,5], :int64).
-        cast(:yale, :int32).
-        cast(:dense, :float64).
-        cast(:list, :int32).
-        cast(:dense, :int16).
-        cast(:list, :int32).
-        cast(:yale, :int64) #.
-        #cast(:list, :int32).
-        #cast(:dense, :int16)
+      cast(:yale, :int32).
+      cast(:dense, :float64).
+      cast(:list, :int32).
+      cast(:dense, :int16).
+      cast(:list, :int32).
+      cast(:yale, :int64) #.
+    #cast(:list, :int32).
+    #cast(:dense, :int16)
     #m.should.equal?(original)
     # For some reason this causes some weird garbage collector problems when we uncomment these. The above lines won't
     # work at all in IRB, but work fine when run in a regular Ruby session.
@@ -241,7 +241,7 @@ describe NMatrix do
         NMatrix.new(storage_type, [3,2,8], 0).shape.should == [3,2,8]
         NMatrix.new(storage_type, [3,2,8], 0).dim.should  == 3
       end
-      
+
       it "returns number of rows and columns" do
         NMatrix.new(storage_type, [7, 4], 3).rows.should == 7
         NMatrix.new(storage_type, [7, 4], 3).cols.should == 4
@@ -263,7 +263,7 @@ describe NMatrix do
 
   it "converts from list to yale properly" do
     m = NMatrix.new(:list, 3, 0)
-    m[0,2] = 333 
+    m[0,2] = 333
     m[2,2] = 777
     n = m.cast(:yale, :int32)
     puts n.capacity

--- a/spec/shortcuts_spec.rb
+++ b/spec/shortcuts_spec.rb
@@ -29,49 +29,49 @@
 require File.join(File.dirname(__FILE__), "spec_helper.rb")
 
 describe NMatrix do
-    
+
   it "zeros() creates a matrix of zeros" do
     m = NMatrix.zeros(3)
     n = NMatrix.new([3, 3], 0)
-    
+
     m.should.eql? n
   end
-  
+
   it "ones() creates a matrix of ones" do
     m = NMatrix.ones(3)
     n = NMatrix.new([3, 3], 1)
-    
-    m.should.eql? n    
+
+    m.should.eql? n
   end
-  
+
   it "eye() creates an identity matrix" do
     m = NMatrix.eye(3)
     identity3 = NMatrix.new([3, 3], [1, 0, 0, 0, 1, 0, 0, 0, 1])
-    
+
     m.should.eql? identity3
   end
-  
+
   it "random() creates a matrix of random numbers" do
     m = NMatrix.random(2)
-    
+
     m.stype.should == :dense
     m.dtype.should == :float64
   end
-  
+
   it "random() only accepts an integer or an array as dimension" do
     m = NMatrix.random([2, 2])
-    
+
     m.stype.should == :dense
     m.dtype.should == :float64
 
     expect { NMatrix.random(2.0) }.to raise_error
     expect { NMatrix.random("not an array or integer") }.to raise_error
   end
- 
+
   it "seq() creates a matrix of integers, sequentially" do
     m = NMatrix.seq(2) # 2x2 matrix.
     value = 0
-    
+
     2.times do |i|
       2.times do |j|
         m[i, j].should == value
@@ -83,7 +83,7 @@ describe NMatrix do
   it "seq() only accepts an integer or a 2-element array as dimension" do
     m = NMatrix.seq([2, 2])
     value = 0
-    
+
     2.times do |i|
       2.times do |j|
         m[i, j].should == value
@@ -94,11 +94,11 @@ describe NMatrix do
     expect { NMatrix.seq([1, 2, 3]) }.to raise_error
     expect { NMatrix.seq("not an array or integer") }.to raise_error
   end
-  
+
   it "indgen() creates a matrix of integers as well as seq()" do
     m = NMatrix.indgen(2) # 2x2 matrix.
     value = 0
-    
+
     2.times do |i|
       2.times do |j|
         m[i, j].should == value
@@ -110,7 +110,7 @@ describe NMatrix do
   it "findgen creates a matrix of floats, sequentially" do
     m = NMatrix.findgen(2) # 2x2 matrix.
     value = 0
-    
+
     2.times do |i|
       2.times do |j|
         (m[i, j]/10).should be_within(Float::EPSILON).of(value.to_f/10)
@@ -118,11 +118,11 @@ describe NMatrix do
       end
     end
   end
- 
+
   it "bindgen() creates a matrix of bytes" do
     m = NMatrix.bindgen(2) # 2x2 matrix.
     value = 0
-    
+
     2.times do |i|
       2.times do |j|
         m[i, j].should == value
@@ -134,7 +134,7 @@ describe NMatrix do
   it "cindgen() creates a matrix of complexes" do
     m = NMatrix.cindgen(2) # 2x2 matrix.
     value = 0
-    
+
     2.times do |i|
       2.times do |j|
         m[i, j].real.should be_within(Float::EPSILON).of(value)
@@ -146,79 +146,79 @@ describe NMatrix do
 
   it "column() returns a NMatrix" do
     m = NMatrix.random(3)
-    
+
     m.column(2).is_a?(NMatrix).should be_true
   end
-  
+
   it "column() accepts a second parameter (only :copy or :reference)" do
     m = NMatrix.random(3)
-    
+
     expect { m.column(1, :copy) }.to_not raise_error
     expect { m.column(1, :reference) }.to_not raise_error
-    
+
     expect { m.column(1, :derp) }.to raise_error
   end
-  
+
   it "row() returns a NMatrix" do
     m = NMatrix.random(3)
-    
+
     m.row(2).is_a?(NMatrix).should be_true
   end
-  
+
   it "row() accepts a second parameter (only :copy or :reference)" do
     m = NMatrix.random(3)
-    
+
     expect { m.row(1, :copy) }.to_not raise_error
     expect { m.row(1, :reference) }.to_not raise_error
-    
+
     expect { m.row(1, :derp) }.to raise_error
   end
 end
 
 describe "NVector" do
-      
+
   it "zeros() creates a vector of zeros" do
     v = NVector.zeros(4)
-    
+
     4.times do |i|
       v[i].should == 0
     end
   end
-  
+
   it "ones() creates a vector of ones" do
     v = NVector.ones(3)
-    
+
     3.times do |i|
       v[i].should == 1
     end
   end
-  
+
   it "random() creates a vector of random numbers" do
     v = NVector.random(4)
     v.dtype.should == :float64
     v.stype.should == :dense
   end
-  
+
   it "seq() creates a vector of integers, sequentially" do
     v = NVector.seq(7)
     i = 0
-    
+
     v.each do |elem|
       elem.should == i
       i += 1
     end
   end
-  
+
   it "seq() only accepts integers as dimension" do
     expect { NVector.seq(3) }.to_not raise_error
 
     expect { NVector.seq([1, 3]) }.to raise_error
     expect { NVector.seq(:wtf) }.to raise_error
   end
-  
+
   it "indgen() creates a vector of integers as well as seq()" do
     v = NVector.indgen(7)
-    i = 0 
+    i = 0
 
     v.each do |elem|
       elem.should == i
@@ -228,12 +228,12 @@ describe "NVector" do
 
   it "findgen creates a vector of floats, sequentially" do
     v = NVector.findgen(2)
-    
+
     2.times do |i|
       (v[i]/10).should be_within(Float::EPSILON).of(i.to_f/10)
     end
   end
- 
+
   it "bindgen() creates a vector of bytes, sequentially" do
     v = NVector.bindgen(7)
     i = 0
@@ -247,7 +247,7 @@ describe "NVector" do
   it "cindgen() creates a vector of complexes, sequentially" do
     v = NVector.cindgen(2)
     value = 0
-    
+
     2.times do |i|
       v[i].real.should be_within(Float::EPSILON).of(value)
       v[i].imag.should be_within(Float::EPSILON).of(0.0)
@@ -259,20 +259,20 @@ describe "NVector" do
   it "linspace() creates a vector with n values equally spaced between a and b" do
     v = NVector.linspace(0, 2, 5)
     i = 0
-    
+
     v.each do |elem|
       elem.should == i * 0.5
       i += 1
     end
-  end  
+  end
 end
 
 describe "Inline constructor" do
-  
+
   it "creates a NMatrix with the given values" do
     m = NMatrix.new([2, 2], [1, 4, 6, 7])
     n = N[[1, 4], [6, 7]]
-    
-    m.should.eql? n 
+
+    m.should.eql? n
   end
 end

--- a/spec/slice_spec.rb
+++ b/spec/slice_spec.rb
@@ -28,223 +28,223 @@ require File.dirname(__FILE__) + "/spec_helper.rb"
 
 describe "Slice operation" do
   [:dense, :list, :yale].each do |stype|
-  context "for #{stype}" do
-    before :each do
-      @m = create_matrix(stype)
-    end
-
-    unless stype == :yale
-    it "should have #is_ref? method" do
-      a = @m[0..1, 0..1]
-      b = @m.slice(0..1, 0..1)
-
-
-      @m.is_ref?.should be_false
-      a.is_ref?.should be_true
-      b.is_ref?.should be_false
-    end
-
-    it "reference should compare with non-reference" do
-      @m.slice(1..2,0..1).should == @m[1..2, 0..1]
-      @m[1..2,0..1].should == @m.slice(1..2, 0..1)
-      @m[1..2,0..1].should == @m[1..2, 0..1]
-    end
-    end # unless stype == :yale
-
-    context "with copying" do
-      it 'should return an NMatrix' do
-        n = @m.slice(0..1,0..1)
-        nm_eql(n, NMatrix.new([2,2], [0,1,3,4], :int32)).should be_true
+    context "for #{stype}" do
+      before :each do
+        @m = create_matrix(stype)
       end
 
-      it 'should return a copy of 2x2 matrix to self elements' do
-        n = @m.slice(1..2,0..1)
-        n.shape.should eql([2,2])
+      unless stype == :yale
+        it "should have #is_ref? method" do
+          a = @m[0..1, 0..1]
+          b = @m.slice(0..1, 0..1)
 
-        n[1,1].should == @m[2,1]
-        n[1,1] = -9
-        @m[2,1].should eql(7)
-      end
 
-      it 'should return a 1x2 matrix with refs to self elements' do
-        n = @m.slice(0,1..2)
-        n.shape.should eql([1,2])
-
-        n[0,0].should == @m[0,1]
-        n[0,0] = -9
-        @m[0,1].should eql(1)
-      end
-
-      it 'should return a 2x1 matrix with refs to self elements' do
-        n = @m.slice(0..1,1)
-        n.shape.should eql([2,1])
-
-        n[0,0].should == @m[0,1]
-        n[0,0] = -9
-        @m[0,1].should eql(1)
-      end
-
-      it 'should be correct slice for range 0..2 and 0...3' do
-        @m.slice(0..2,0..2).should == @m.slice(0...3,0...3)
-      end
-    
-      [:dense, :list, :yale].each do |cast_type|
-        it "should cast from #{stype.upcase} to #{cast_type.upcase}" do
-          nm_eql(@m.slice(1..2, 1..2).cast(cast_type, :int32), @m.slice(1..2,1..2)).should be_true
-          nm_eql(@m.slice(0..1, 1..2).cast(cast_type, :int32), @m.slice(0..1,1..2)).should be_true
-          nm_eql(@m.slice(1..2, 0..1).cast(cast_type, :int32), @m.slice(1..2,0..1)).should be_true
-          nm_eql(@m.slice(0..1, 0..1).cast(cast_type, :int32), @m.slice(0..1,0..1)).should be_true
-
-          # Non square
-          nm_eql(@m.slice(0..2, 1..2).cast(cast_type, :int32), @m.slice(0..2,1..2)).should be_true
-          nm_eql(@m.slice(1..2, 0..2).cast(cast_type, :int32), @m.slice(1..2,0..2)).should be_true
-
-          # Full
-          nm_eql(@m.slice(0..2, 0..2).cast(cast_type, :int32), @m).should be_true
+          @m.is_ref?.should be_false
+          a.is_ref?.should be_true
+          b.is_ref?.should be_false
         end
-      end
-    end
 
-    if stype == :yale
-      context "by reference" do
-        it "should raise an error" do
-          expect{ @m[1..2,1..2] }.to raise_error(NotImplementedError)
+        it "reference should compare with non-reference" do
+          @m.slice(1..2,0..1).should == @m[1..2, 0..1]
+          @m[1..2,0..1].should == @m.slice(1..2, 0..1)
+          @m[1..2,0..1].should == @m[1..2, 0..1]
         end
-      end
+      end # unless stype == :yale
 
-      context "by copy" do
-        it "should correctly preserve zeros" do
-          @m = NMatrix.new(:yale, 3, :int64)
-          column_slice = @m.column(2, :copy)
-          column_slice[0,0].should == 0
-          column_slice[1,0].should == 0
-          column_slice[2,0].should == 0
+      context "with copying" do
+        it 'should return an NMatrix' do
+          n = @m.slice(0..1,0..1)
+          nm_eql(n, NMatrix.new([2,2], [0,1,3,4], :int32)).should be_true
         end
-      end
-    else
-    context "by reference" do
-      it 'should return an NMatrix' do
-        n = @m[0..1,0..1]
-        nm_eql(n, NMatrix.new([2,2], [0,1,3,4], :int32)).should be_true
-      end
 
-      it 'should return a 2x2 matrix with refs to self elements' do
-        n = @m[1..2,0..1]
-        n.shape.should eql([2,2])
+        it 'should return a copy of 2x2 matrix to self elements' do
+          n = @m.slice(1..2,0..1)
+          n.shape.should eql([2,2])
 
-        n[0,0].should == @m[1,0]
-        n[0,0] = -9
-        @m[1,0].should eql(-9)
-      end
+          n[1,1].should == @m[2,1]
+          n[1,1] = -9
+          @m[2,1].should eql(7)
+        end
 
-      it 'should return a 1x2 matrix with refs to self elements' do
-        n = @m[0,1..2]
-        n.shape.should eql([1,2])
+        it 'should return a 1x2 matrix with refs to self elements' do
+          n = @m.slice(0,1..2)
+          n.shape.should eql([1,2])
 
-        n[0,0].should == @m[0,1]
-        n[0,0] = -9
-        @m[0,1].should eql(-9)
-      end
+          n[0,0].should == @m[0,1]
+          n[0,0] = -9
+          @m[0,1].should eql(1)
+        end
 
-      it 'should return a 2x1 matrix with refs to self elements' do
-        n = @m[0..1,1]
-        n.shape.should eql([2,1])
+        it 'should return a 2x1 matrix with refs to self elements' do
+          n = @m.slice(0..1,1)
+          n.shape.should eql([2,1])
 
-        n[0,0].should == @m[0,1]
-        n[0,0] = -9
-        @m[0,1].should eql(-9)
-      end
+          n[0,0].should == @m[0,1]
+          n[0,0] = -9
+          @m[0,1].should eql(1)
+        end
 
-      it 'should set value from NMatrix'
+        it 'should be correct slice for range 0..2 and 0...3' do
+          @m.slice(0..2,0..2).should == @m.slice(0...3,0...3)
+        end
 
-      it 'should slice again' do
-        n = @m[1..2, 1..2]
-        nm_eql(n[1,0..1], NMatrix.new([1,2], [7,8])).should be_true
-      end
+        [:dense, :list, :yale].each do |cast_type|
+          it "should cast from #{stype.upcase} to #{cast_type.upcase}" do
+            nm_eql(@m.slice(1..2, 1..2).cast(cast_type, :int32), @m.slice(1..2,1..2)).should be_true
+            nm_eql(@m.slice(0..1, 1..2).cast(cast_type, :int32), @m.slice(0..1,1..2)).should be_true
+            nm_eql(@m.slice(1..2, 0..1).cast(cast_type, :int32), @m.slice(1..2,0..1)).should be_true
+            nm_eql(@m.slice(0..1, 0..1).cast(cast_type, :int32), @m.slice(0..1,0..1)).should be_true
 
-      it 'should be correct slice for range 0..2 and 0...3' do
-        @m[0..2,0..2].should == @m[0...3,0...3]
-      end
+            # Non square
+            nm_eql(@m.slice(0..2, 1..2).cast(cast_type, :int32), @m.slice(0..2,1..2)).should be_true
+            nm_eql(@m.slice(1..2, 0..2).cast(cast_type, :int32), @m.slice(1..2,0..2)).should be_true
 
-      if stype == :dense
-        [:byte,:int8,:int16,:int32,:int64,:float32,:float64,:rational64,:rational128].each do |left_dtype|
-          [:byte,:int8,:int16,:int32,:int64,:float32,:float64,:rational64,:rational128].each do |right_dtype|
-
-            # Won't work if they're both 1-byte, due to overflow.
-            next if [:byte,:int8].include?(left_dtype) && [:byte,:int8].include?(right_dtype)
-
-            # For now, don't bother testing int-int mult.
-            #next if [:int8,:int16,:int32,:int64].include?(left_dtype) && [:int8,:int16,:int32,:int64].include?(right_dtype)
-            it "handles #{left_dtype.to_s} dot #{right_dtype.to_s} matrix multiplication" do
-              #STDERR.puts "dtype=#{dtype.to_s}"
-              #STDERR.puts "2"
-
-              nary = if left_dtype.to_s =~ /complex/
-                       COMPLEX_MATRIX43A_ARRAY
-                     elsif left_dtype.to_s =~ /rational/
-                       RATIONAL_MATRIX43A_ARRAY
-                     else
-                       MATRIX43A_ARRAY
-                     end
-
-              mary = if right_dtype.to_s =~ /complex/
-                       COMPLEX_MATRIX32A_ARRAY
-                     elsif right_dtype.to_s =~ /rational/
-                       RATIONAL_MATRIX32A_ARRAY
-                     else
-                       MATRIX32A_ARRAY
-                     end
-
-              n = NMatrix.new([4,3], nary, left_dtype)[1..3,1..2]
-              m = NMatrix.new([3,2], mary, right_dtype)[1..2,0..1]
-
-              r = n.dot m
-              r.shape.should eql([3,2])
-
-              r[0,0].should == 219.0
-              r[0,1].should == 185.0
-              r[1,0].should == 244.0
-              r[1,1].should == 205.0
-              r[2,0].should == 42.0
-              r[2,1].should == 35.0
-
-            end
+            # Full
+            nm_eql(@m.slice(0..2, 0..2).cast(cast_type, :int32), @m).should be_true
           end
         end
       end
 
-      it 'should be cleaned up by garbage collector without errors'  do
-        1.times do
-          n = @m[1..2,0..1]
+      if stype == :yale
+        context "by reference" do
+          it "should raise an error" do
+            expect{ @m[1..2,1..2] }.to raise_error(NotImplementedError)
+          end
         end
-        GC.start
-        @m.should == NMatrix.new(:dense, [3,3], (0..9).to_a, :int32).cast(stype, :int32)
-        n = nil
-        1.times do
-          m = NMatrix.new(:dense, [2,2], [1,2,3,4]).cast(stype, :int32)
-          n = m[0..1,0..1]
+
+        context "by copy" do
+          it "should correctly preserve zeros" do
+            @m = NMatrix.new(:yale, 3, :int64)
+            column_slice = @m.column(2, :copy)
+            column_slice[0,0].should == 0
+            column_slice[1,0].should == 0
+            column_slice[2,0].should == 0
+          end
         end
-        GC.start
-        n.should == NMatrix.new(:dense, [2,2], [1,2,3,4]).cast(stype, :int32)
-      end
+      else
+        context "by reference" do
+          it 'should return an NMatrix' do
+            n = @m[0..1,0..1]
+            nm_eql(n, NMatrix.new([2,2], [0,1,3,4], :int32)).should be_true
+          end
 
-      [:dense, :list, :yale].each do |cast_type|
-        it "should cast from #{stype.upcase} to #{cast_type.upcase}" do
-          nm_eql(@m[1..2, 1..2].cast(cast_type, :int32), @m[1..2,1..2]).should be_true
-          nm_eql(@m[0..1, 1..2].cast(cast_type, :int32), @m[0..1,1..2]).should be_true
-          nm_eql(@m[1..2, 0..1].cast(cast_type, :int32), @m[1..2,0..1]).should be_true
-          nm_eql(@m[0..1, 0..1].cast(cast_type, :int32), @m[0..1,0..1]).should be_true
+          it 'should return a 2x2 matrix with refs to self elements' do
+            n = @m[1..2,0..1]
+            n.shape.should eql([2,2])
 
-          # Non square
-          nm_eql(@m[0..2, 1..2].cast(cast_type, :int32), @m[0..2,1..2]).should be_true
-          nm_eql(@m[1..2, 0..2].cast(cast_type, :int32), @m[1..2,0..2]).should be_true
+            n[0,0].should == @m[1,0]
+            n[0,0] = -9
+            @m[1,0].should eql(-9)
+          end
 
-          # Full
-          nm_eql(@m[0..2, 0..2].cast(cast_type, :int32), @m).should be_true
+          it 'should return a 1x2 matrix with refs to self elements' do
+            n = @m[0,1..2]
+            n.shape.should eql([1,2])
+
+            n[0,0].should == @m[0,1]
+            n[0,0] = -9
+            @m[0,1].should eql(-9)
+          end
+
+          it 'should return a 2x1 matrix with refs to self elements' do
+            n = @m[0..1,1]
+            n.shape.should eql([2,1])
+
+            n[0,0].should == @m[0,1]
+            n[0,0] = -9
+            @m[0,1].should eql(-9)
+          end
+
+          it 'should set value from NMatrix'
+
+          it 'should slice again' do
+            n = @m[1..2, 1..2]
+            nm_eql(n[1,0..1], NMatrix.new([1,2], [7,8])).should be_true
+          end
+
+          it 'should be correct slice for range 0..2 and 0...3' do
+            @m[0..2,0..2].should == @m[0...3,0...3]
+          end
+
+          if stype == :dense
+            [:byte,:int8,:int16,:int32,:int64,:float32,:float64,:rational64,:rational128].each do |left_dtype|
+              [:byte,:int8,:int16,:int32,:int64,:float32,:float64,:rational64,:rational128].each do |right_dtype|
+
+                # Won't work if they're both 1-byte, due to overflow.
+                next if [:byte,:int8].include?(left_dtype) && [:byte,:int8].include?(right_dtype)
+
+                # For now, don't bother testing int-int mult.
+                #next if [:int8,:int16,:int32,:int64].include?(left_dtype) && [:int8,:int16,:int32,:int64].include?(right_dtype)
+                it "handles #{left_dtype.to_s} dot #{right_dtype.to_s} matrix multiplication" do
+                  #STDERR.puts "dtype=#{dtype.to_s}"
+                  #STDERR.puts "2"
+
+                  nary = if left_dtype.to_s =~ /complex/
+                           COMPLEX_MATRIX43A_ARRAY
+                         elsif left_dtype.to_s =~ /rational/
+                           RATIONAL_MATRIX43A_ARRAY
+                         else
+                           MATRIX43A_ARRAY
+                         end
+
+                  mary = if right_dtype.to_s =~ /complex/
+                           COMPLEX_MATRIX32A_ARRAY
+                         elsif right_dtype.to_s =~ /rational/
+                           RATIONAL_MATRIX32A_ARRAY
+                         else
+                           MATRIX32A_ARRAY
+                         end
+
+                  n = NMatrix.new([4,3], nary, left_dtype)[1..3,1..2]
+                  m = NMatrix.new([3,2], mary, right_dtype)[1..2,0..1]
+
+                  r = n.dot m
+                  r.shape.should eql([3,2])
+
+                  r[0,0].should == 219.0
+                  r[0,1].should == 185.0
+                  r[1,0].should == 244.0
+                  r[1,1].should == 205.0
+                  r[2,0].should == 42.0
+                  r[2,1].should == 35.0
+
+                end
+              end
+            end
+          end
+
+          it 'should be cleaned up by garbage collector without errors'  do
+            1.times do
+              n = @m[1..2,0..1]
+            end
+            GC.start
+            @m.should == NMatrix.new(:dense, [3,3], (0..9).to_a, :int32).cast(stype, :int32)
+            n = nil
+            1.times do
+              m = NMatrix.new(:dense, [2,2], [1,2,3,4]).cast(stype, :int32)
+              n = m[0..1,0..1]
+            end
+            GC.start
+            n.should == NMatrix.new(:dense, [2,2], [1,2,3,4]).cast(stype, :int32)
+          end
+
+          [:dense, :list, :yale].each do |cast_type|
+            it "should cast from #{stype.upcase} to #{cast_type.upcase}" do
+              nm_eql(@m[1..2, 1..2].cast(cast_type, :int32), @m[1..2,1..2]).should be_true
+              nm_eql(@m[0..1, 1..2].cast(cast_type, :int32), @m[0..1,1..2]).should be_true
+              nm_eql(@m[1..2, 0..1].cast(cast_type, :int32), @m[1..2,0..1]).should be_true
+              nm_eql(@m[0..1, 0..1].cast(cast_type, :int32), @m[0..1,0..1]).should be_true
+
+              # Non square
+              nm_eql(@m[0..2, 1..2].cast(cast_type, :int32), @m[0..2,1..2]).should be_true
+              nm_eql(@m[1..2, 0..2].cast(cast_type, :int32), @m[1..2,0..2]).should be_true
+
+              # Full
+              nm_eql(@m[0..2, 0..2].cast(cast_type, :int32), @m).should be_true
+            end
+          end
         end
       end
-      end
-    end
     end # unless stype == :yale
   end
 
@@ -257,11 +257,11 @@ describe "Slice operation" do
         n.shape[1].times do |j|
           if n[i,j] != m[i,j]
             puts "n[#{i},#{j}] != m[#{i},#{j}] (#{n[i,j]} != #{m[i,j]})"
-            return false 
+            return false
           end
         end
       end
       true
-    end 
+    end
   end
 end


### PR DESCRIPTION
I forgot to clean up directories other than `lib/` for #72.

This is the same idea. 2 space indent instead of tabs, remove trailing whitespace, no other changes.

`rake spec` shows no new issues.
