### PR TITLE
Fixes in extconf.rb

### DIFF
--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -169,7 +169,7 @@ def find_newer_gplusplus #:nodoc:
 end
 
 def gplusplus_version #:nodoc:
-  `#{CONFIG['CXX']} -v 2>&1`.lines.to_a.last.match(/gcc\sversion\s(\d\.\d.\d)/).captures.first
+  `LANG="en_US" #{CONFIG['CXX']} -v 2>&1`.lines.to_a.last.match(/gcc\sversion\s(\d\.\d.\d)/).captures.first
 end
 
 


### PR DESCRIPTION
This pull request has two purposes:
1. Add g++ 4.8 to the list of newer g++ versions;
2. Apply the patch found in issue #77, as it might be useful for more people.
