### PR TITLE
Add .gem to gem install command

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ Rake::GemPackageTask.new(gemspec).define
 
 desc "install the gem locally"
 task :install => [:package] do
-  sh %{gem install pkg/nmatrix-#{NMatrix::VERSION}}
+  sh %{gem install pkg/nmatrix-#{NMatrix::VERSION}.gem}
 end
 
 require 'rspec/core/rake_task'


### PR DESCRIPTION
See comments in #58

Bundler uses `.gem`, as do tons of other gems. It is pretty much universally accepted that this is a best practice to ensure the gem builds and installs on all platforms/environments/Rubygems versions, etc. https://github.com/carlhuda/bundler/blob/master/lib/bundler/gem_helper.rb#L92
