### PR TITLE
added spec for return from each and each_stored_with_indices (see #87)

### DIFF
--- a/spec/nmatrix_spec.rb
+++ b/spec/nmatrix_spec.rb
@@ -292,6 +292,37 @@ describe NMatrix do
     end
   end
 
+  context "dense" do
+    it "should return nil when each is called with a block" do
+      a = NMatrix.new(2, 1)
+      val = (a.each { })
+      val.should be_nil
+    end
+    
+    it "should return nil when each_stored_with_indices is called with a block" do
+      a = NMatrix.new(2,1)
+      val = (a.each_stored_with_indices { })
+      val.should be_nil
+    end
+  end
+
+  [:list, :yale].each do |storage_type|
+    context storage_type do
+      it "should return the matrix being iterated over when each_stored_with_indices is called with a block" do
+        n = NMatrix.new(storage_type, [2,3], storage_type == :yale ? :float64 : 1.1)
+        val = (n.each_stored_with_indices { })
+        val.should eq n
+      end
+
+      it "should return an enumerator when each_stored_with_indices is called without a block" do
+        n = NMatrix.new(storage_type, [2,3], storage_type == :yale ? :float64 : 1.1)
+        val = n.each_stored_with_indices
+        val.should be_a Enumerator
+      end
+
+    end
+  end
+      
   it "should iterate through element 256 without a segfault" do
     t = NVector.random(256)
     t.each { |x| x + 0 }


### PR DESCRIPTION
Looks like both list and Yale were ok with respect to always returning a value in `each_stored_with_indices`; they return the matrix over which the iteration is happening if a block is provided.  I chose `nil` for the dense return value originally, but perhaps it is worth switching that over to returning the matrix for consistency?

The added specs reflect the current state of the return values for each storage type.
