### PR TITLE
Added extra clapack and cblas header check to extconf.rb, which allows compile on ubuntu

### DIFF
--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -131,11 +131,11 @@ $srcs = [
 # (substituting in the path of your cblas.h and clapack.h for the path I used). -- JW 8/27/12
 
 
-unless have_library("lapack")
+unless have_library("lapack") and have_header("clapack.h")
   dir_config("lapack", ["/usr/include/atlas"], ["/usr/local/lib", "/usr/local/atlas/lib"])
 end
 
-unless have_library("cblas")
+unless have_library("cblas") and have_header("cblas.h")
   dir_config("cblas", ["/usr/local/atlas/include", "/usr/include/atlas"], ["/usr/local/lib", "/usr/local/atlas/lib"])
 end
 


### PR DESCRIPTION
(Fix for #88.)

This commit lets you compile error-free on Ubuntu 13.04 with ATLAS from the package repository using:

```
sudo apt-get install libatlas3-base libatlas-base-dev
bundle install
rake compile
```

without having to set any environment variables or anything else special.  (Though if lapack is installed separately from ATLAS, it will still cause problems when trying to load nmatrix in a program.)

I only have access to Ubuntu 13.04 right now, so I haven't tested other versions.  To those out there with other Ubuntu versions: does this fix the issue?  To those out there with other linux distros or OS X: does this break anything?
