### PR TITLE
Minor specs fix (plus lots of whitespace removed)

### DIFF
--- a/spec/nmatrix_spec.rb
+++ b/spec/nmatrix_spec.rb
@@ -31,7 +31,7 @@ describe NMatrix do
 
   it "calculates exact determinants on small square matrices" do
     a = NMatrix.new(:dense, 2, [1,2,3,4], :int64)
-    x = a.det_exact
+    a.det_exact.should == -2
   end
 
   it "calculates determinants" do
@@ -314,7 +314,7 @@ describe NMatrix do
       val = (a.each { })
       val.should eq a
     end
-    
+
     it "should return the matrix being iterated over when each_stored_with_indices is called with a block" do
       a = NMatrix.new(2,1)
       val = (a.each_stored_with_indices { })
@@ -338,13 +338,13 @@ describe NMatrix do
 
     end
   end
-      
+
   it "should iterate through element 256 without a segfault" do
     t = NVector.random(256)
     t.each { |x| x + 0 }
   end
 
-  context "mapping and reduction related functions" do 
+  context "mapping and reduction related functions" do
 
     before :each do
       @nm_1d = N[5.0,0.0,1.0,2.0,3.0]
@@ -361,7 +361,7 @@ describe NMatrix do
       @nm_2d.mean.should eq N[[1.0,2.0]]
     end
 
-    it "should calculate the minimum along the specified dimension" do 
+    it "should calculate the minimum along the specified dimension" do
       @nm_1d.min.should eq 0.0
       @nm_2d.min.should eq N[[0.0, 1.0]]
       @nm_2d.min(1).should eq N[[0.0], [2.0]]
@@ -387,11 +387,11 @@ describe NMatrix do
       @nm_2d.std(1).should eq N[[Math.sqrt(0.5)], [Math.sqrt(0.5)]]
     end
 
-    it "should raise an ArgumentError when any invalid dimension is provided" do 
+    it "should raise an ArgumentError when any invalid dimension is provided" do
       expect { @nm_1d.mean(3) }.to raise_exception(ArgumentError)
     end
 
-    it "should convert to float if it contains only a single element" do 
+    it "should convert to float if it contains only a single element" do
       N[4.0].to_f.should eq 4.0
       N[[[[4.0]]]].to_f.should eq 4.0
     end
@@ -400,7 +400,7 @@ describe NMatrix do
       expect { @nm_1d.to_f }.to raise_error(IndexError)
     end
 
-    it "should map a block to all elements" do 
+    it "should map a block to all elements" do
       @nm_1d.map { |e| e ** 2 }.should eq N[25.0,0.0,1.0,4.0,9.0]
       @nm_2d.map { |e| e ** 2 }.should eq N[[0.0,1.0],[4.0,9.0]]
     end
@@ -510,13 +510,10 @@ describe NMatrix do
         NMatrix.ones_like(@nm_2d).should eq N[[1.0, 1.0], [1.0, 1.0]]
       end
 
-      it "should create an nmatrix of zeros with dimensions and type the same as its argument" do 
+      it "should create an nmatrix of zeros with dimensions and type the same as its argument" do
         NMatrix.zeros_like(@nm_1d).should eq N[0.0, 0.0, 0.0, 0.0, 0.0]
         NMatrix.zeros_like(@nm_2d).should eq N[[0.0, 0.0], [0.0, 0.0]]
       end
-
     end
-
   end
-  
 end


### PR DESCRIPTION
I was working on determinants and just saw a (very simple) spec without a `should` expression. Nothing great -- this is a really small patch.

Let's keep the codebase clean. :)
