### PR TITLE
added travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+env:
+  - CPLUS_INCLUDE_PATH=/usr/include/atlas C_INCLUDE_PATH=/usr/include/atlas
+rvm:
+  - "1.9.3"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libatlas-base-dev
+script: bundle exec rake compile && bundle exec rake spec
+


### PR DESCRIPTION
Before merging, you'll need to enable it for the repository.  Instructions are here: http://about.travis-ci.org/docs/user/getting-started/

The build currently fails due to two tests failing:

NMatrix::BLAS complex64 cblas exposes rotg
NMatrix::BLAS complex128 cblas exposes rotg

Are these the current expected failures?

Also, I've set it to test against 1.9.3.  Are there other ruby versions currently being targeted?
