### PR TITLE
attempt to fix compilation header paths on ubuntu without breaking OSX

### DIFF
--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -150,16 +150,17 @@ unless have_library("atlas")
   dir_config("atlas", idefaults[:atlas], ldefaults[:atlas])
 end
 
+# this needs to go before cblas.h checks -- on Ubuntu, the clapack in the
+# include path found for cblas.h doesn't seem to contain all the necessary 
+# functions
+have_header("clapack.h")
+
+# this ensures that we find the header on Ubuntu, where by default the library 
+# can be found but not the header
 unless have_header("cblas.h")
   find_header("cblas.h", *idefaults[:cblas])
 end
 
-unless have_header("clapack.h")
-  find_header("clapack.h", *idefaults[:clapack])
-end
-
-#find_library("lapack", "clapack_dgetrf")
-have_header("clapack.h")
 have_header("cblas.h")
 
 have_func("clapack_dgetrf", ["cblas.h", "clapack.h"])
@@ -168,7 +169,7 @@ have_func("dgesvd_", "clapack.h")
 
 have_func("cblas_dgemm", "cblas.h")
 
-
+#find_library("lapack", "clapack_dgetrf")
 #find_library("cblas", "cblas_dgemm")
 #find_library("atlas", "ATL_dgemmNN")
 


### PR DESCRIPTION
Another attempt at fixing #88.  This time I left the logic of the `dir_config` statements alone (though I pulled out the paths to allow reuse), which should hopefully prevent any problems associated with linking as in #69 (and #97).  I added two additional header checks after the `dir_config` part in order to fix the case where it can find the library but not the header on Ubuntu.

Tested on:
- Ubuntu 13.04, where it will now compile out of the box with `rake compile` (no `CPLUS_INCLUDE_PATH` hack necessary).  Atlas was installed with `apt-get install libatlas-base-dev`.
- OSX 10.8.4 with gcc 4.8.1 (not entirely sure how atlas was installed, but it's not my computer so I don't want to go messing with it), where it also compiles out of the box wtih `rake compile`.
- Ubuntu 12.04, which still requires `CPLUS_INCLUDE_PATH=/usr/include/atlas` with `rake compile` when atlas is installed by `apt-get install libatlas-base-dev`.  (Otherwise it detects the wrong cblas.h -- `apt-get` installs two of them -- and I haven't been able to get it to choose the right one.)
