### PR TITLE
Make NMatrix able to install to Fedora 19 (x86_64)

### DIFF
--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -138,9 +138,9 @@ idefaults = {lapack: ["/usr/include/atlas"],
              cblas: ["/usr/local/atlas/include", "/usr/include/atlas"],
              atlas: ["/usr/local/atlas/include", "/usr/include/atlas"]}
 
-ldefaults = {lapack: ["/usr/local/lib", "/usr/local/atlas/lib"],
-             cblas: ["/usr/local/lib", "/usr/local/atlas/lib"],
-             atlas: ["/usr/local/atlas/lib", "/usr/local/lib", "/usr/lib"]}
+ldefaults = {lapack: ["/usr/local/lib", "/usr/local/atlas/lib", "/usr/lib64/atlas"],
+             cblas: ["/usr/local/lib", "/usr/local/atlas/lib", "/usr/lib64/atlas"],
+             atlas: ["/usr/local/atlas/lib", "/usr/local/lib", "/usr/lib", "/usr/lib64/atlas"]}
 
 unless have_library("lapack")
   dir_config("lapack", idefaults[:lapack], ldefaults[:lapack])


### PR DESCRIPTION
At this moment, NMatrix is unable to be installed to Fedora 19 (x86_64). This pull request fixes it by adding the necessary `/usr/lib64/atlas` path to the `ldefaults` section on `extconf.rb`.
