### PR TITLE
fix possible access after free / double free bug #143

### DIFF
--- a/ext/nmatrix/storage/dense.cpp
+++ b/ext/nmatrix/storage/dense.cpp
@@ -158,7 +158,7 @@ namespace nm { namespace dense_storage {
     // Only free v if it was allocated in this function.
     if (nm_and_free.first && nm_and_free.second)
       nm_delete(nm_and_free.first);
-    else
+    else if (! nm_and_free.first)
       xfree(v);
   }
 


### PR DESCRIPTION
In dense.cpp in the function nm::dense_storage::set, when setting a slice from
a right hand side dense NMatrix with same dtype, v is set to a reference to the
elements array of the rhs matrix, but nm_and_free.second is
false, leading to xfree(v) being called, wiping out the elements array that is
still potentially in use.

Added a check for whether nm_and_free.first was defined (independent of
.second) to keep this from happening.
