### PR TITLE
Undefined method 'captures' during installation

### DIFF
--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -194,9 +194,14 @@ def find_newer_gplusplus #:nodoc:
 end
 
 def gplusplus_version #:nodoc:
-  version_match = `LANG="en_US" #{CONFIG['CXX']} -v 2>&1`.lines.to_a.find { |l| l.match(/version\s/) }.match(/version\s(\d\.\d(\.\d)?)/)
-  raise("unable to determine g++ version (match to get version was nil)") if version_match.nil?
-  version_match.captures.first
+  cxxvar = proc { |n| `#{CONFIG['CXX']} -E -dM - </dev/null | grep #{n}`.chomp.split(' ')[2] }
+  major = cxxvar.call('__GNUC__')
+  minor = cxxvar.call('__GNUC_MINOR__')
+  patch = cxxvar.call('__GNUC_PATCHLEVEL__')
+
+  raise("unable to determine g++ version (match to get version was nil)") if major.nil? || minor.nil? || patch.nil?
+
+  "#{major}.#{minor}.#{patch}"
 end
 
 


### PR DESCRIPTION
```
Fetching: nmatrix-0.0.9.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing nmatrix:
    ERROR: Failed to build gem native extension.

    /Users/sheerun/.rbenv/versions/2.0.0-p247/bin/ruby extconf.rb
checking for main() in -llapack... yes
checking for main() in -lcblas... yes
checking for main() in -latlas... no
checking for clapack.h... no
checking for cblas.h... no
checking for cblas.h in /usr/local/atlas/include,/usr/include/atlas... no
checking for cblas.h... no
checking for clapack_dgetrf() in cblas.h,clapack.h... no
checking for clapack_dgetri() in cblas.h,clapack.h... no
checking for dgesvd_() in clapack.h... no
checking for cblas_dgemm() in cblas.h... no
Exception `NoMethodError' at extconf.rb:205 - undefined method `captures' for nil:NilClass
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
    --with-opt-dir
    --without-opt-dir
    --with-opt-include
    --without-opt-include=${opt-dir}/include
    --with-opt-lib
    --without-opt-lib=${opt-dir}/lib
    --with-make-prog
    --without-make-prog
    --srcdir=.
    --curdir
    --ruby=/Users/sheerun/.rbenv/versions/2.0.0-p247/bin/ruby
    --with-lapacklib
    --without-lapacklib
    --with-cblaslib
    --without-cblaslib
    --with-atlaslib
    --without-atlaslib
    --with-atlas-dir
    --without-atlas-dir
    --with-atlas-include
    --without-atlas-include=${atlas-dir}/include
    --with-atlas-lib
    --without-atlas-lib=${atlas-dir}/
extconf.rb:205:in `gplusplus_version': undefined method `captures' for nil:NilClass (NoMethodError)
    from extconf.rb:213:in `<main>'
```

```
ruby -v
ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin13.0.1]
```

```
g++ -v
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
Target: x86_64-apple-darwin13.0.1
Thread model: posix
```

The system is Mavericks 10.9 (not upgraded).
