### PR TITLE
Prefer lapack and blas headers from atlas subdirectory

### DIFF
--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -204,18 +204,15 @@ unless have_library("atlas")
   dir_config("atlas", idefaults[:atlas], ldefaults[:atlas])
 end
 
-# this needs to go before cblas.h checks -- on Ubuntu, the clapack in the
-# include path found for cblas.h doesn't seem to contain all the necessary 
-# functions
-have_header("clapack.h")
-
-# this ensures that we find the header on Ubuntu, where by default the library 
-# can be found but not the header
-unless have_header("cblas.h")
-  find_header("cblas.h", *idefaults[:cblas])
+# If BLAS and LAPACK headers are in an atlas directory, prefer those. Otherwise,
+# we try our luck with the default location.
+if have_header("atlas/cblas.h")
+  have_header("atlas/clapack.h")
+else
+  have_header("cblas.h")
+  have_header("clapack.h")
 end
 
-have_header("cblas.h")
 
 have_func("clapack_dgetrf", ["cblas.h", "clapack.h"])
 have_func("clapack_dgetri", ["cblas.h", "clapack.h"])
@@ -228,7 +225,6 @@ have_func("cblas_dgemm", "cblas.h")
 #find_library("lapack", "clapack_dgetrf")
 #find_library("cblas", "cblas_dgemm")
 #find_library("atlas", "ATL_dgemmNN")
-
 # Order matters here: ATLAS has to go after LAPACK: http://mail.scipy.org/pipermail/scipy-user/2007-January/010717.html
 $libs += " -llapack -lcblas -latlas "
 #$libs += " -lprofiler "

--- a/ext/nmatrix/math.cpp
+++ b/ext/nmatrix/math.cpp
@@ -150,8 +150,10 @@
  */
 
 extern "C" {
-#ifdef HAVE_CLAPACK_H
+#if defined HAVE_CLAPACK_H
   #include <clapack.h>
+#elif defined HAVE_ATLAS_CLAPACK_H
+  #include <atlas/clapack.h>
 #endif
 
   static VALUE nm_cblas_nrm2(VALUE self, VALUE n, VALUE x, VALUE incx);

--- a/ext/nmatrix/math/asum.h
+++ b/ext/nmatrix/math/asum.h
@@ -86,7 +86,7 @@ inline ReturnDType asum(const int N, const DType* X, const int incX) {
 }
 
 
-#ifdef HAVE_CBLAS_H
+#if defined HAVE_CBLAS_H || defined HAVE_ATLAS_CBLAS_H
 template <>
 inline float asum(const int N, const float* X, const int incX) {
   return cblas_sasum(N, X, incX);

--- a/ext/nmatrix/math/gemm.h
+++ b/ext/nmatrix/math/gemm.h
@@ -31,7 +31,11 @@
 # define GEMM_H
 
 extern "C" { // These need to be in an extern "C" block or you'll get all kinds of undefined symbol errors.
+#if defined HAVE_CBLAS_H
   #include <cblas.h>
+#elif defined HAVE_ATLAS_CBLAS_H
+  #include <atlas/cblas.h>
+#endif
 }
 
 

--- a/ext/nmatrix/math/gemv.h
+++ b/ext/nmatrix/math/gemv.h
@@ -31,7 +31,11 @@
 # define GEMV_H
 
 extern "C" { // These need to be in an extern "C" block or you'll get all kinds of undefined symbol errors.
+#if defined HAVE_CBLAS_H
   #include <cblas.h>
+#elif defined HAVE_ATLAS_CBLAS_H
+  #include <atlas/cblas.h>
+#endif
 }
 
 

--- a/ext/nmatrix/math/getrs.h
+++ b/ext/nmatrix/math/getrs.h
@@ -60,7 +60,11 @@
 #define GETRS_H
 
 extern "C" {
+#if defined HAVE_CBLAS_H
   #include <cblas.h>
+#elif defined HAVE_ATLAS_CBLAS_H
+  #include <atlas/cblas.h>
+#endif
 }
 
 namespace nm { namespace math {

--- a/ext/nmatrix/math/inc.h
+++ b/ext/nmatrix/math/inc.h
@@ -31,11 +31,17 @@
 
 
 extern "C" { // These need to be in an extern "C" block or you'll get all kinds of undefined symbol errors.
+#if defined HAVE_CBLAS_H
   #include <cblas.h>
+#elif defined HAVE_ATLAS_CBLAS_H
+  #include <atlas/cblas.h>
+#endif
 
-  #ifdef HAVE_CLAPACK_H
-    #include <clapack.h>
-  #endif
+#if defined HAVE_CLAPACK_H
+  #include <clapack.h>
+#elif defined HAVE_ATLAS_CLAPACK_H
+  #include <atlas/clapack.h>
+#endif
 }
 
 #endif // INC_H

--- a/ext/nmatrix/math/math.h
+++ b/ext/nmatrix/math/math.h
@@ -69,11 +69,17 @@
  */
 
 extern "C" { // These need to be in an extern "C" block or you'll get all kinds of undefined symbol errors.
+#if defined HAVE_CBLAS_H
   #include <cblas.h>
+#elif defined HAVE_ATLAS_CBLAS_H
+  #include <atlas/cblas.h>
+#endif
 
-  #ifdef HAVE_CLAPACK_H
-    #include <clapack.h>
-  #endif
+#if defined HAVE_CLAPACK_H
+  #include <clapack.h>
+#elif defined HAVE_ATLAS_CLAPACK_H
+  #include <atlas/clapack.h>
+#endif
 }
 
 #include <algorithm> // std::min, std::max
@@ -531,7 +537,7 @@ inline void smmp_sort_columns(const size_t n, const IType* ia, IType* ja, DType*
  */
 template <typename DType>
 inline int potrf(const enum CBLAS_ORDER order, const enum CBLAS_UPLO uplo, const int N, DType* A, const int lda) {
-#ifdef HAVE_CLAPACK_H
+#if defined HAVE_CLAPACK_H || defined HAVE_ATLAS_CLAPACK_H
   rb_raise(rb_eNotImpError, "not yet implemented for non-BLAS dtypes");
 #else
   rb_raise(rb_eNotImpError, "only CLAPACK version implemented thus far");
@@ -539,7 +545,7 @@ inline int potrf(const enum CBLAS_ORDER order, const enum CBLAS_UPLO uplo, const
   return 0;
 }
 
-#ifdef HAVE_CLAPACK_H
+#if defined HAVE_CLAPACK_H || defined HAVE_ATLAS_CLAPACK_H
 template <>
 inline int potrf(const enum CBLAS_ORDER order, const enum CBLAS_UPLO uplo, const int N, float* A, const int lda) {
   return clapack_spotrf(order, uplo, N, A, lda);
@@ -928,7 +934,7 @@ inline void lauum(const enum CBLAS_ORDER order, const enum CBLAS_UPLO uplo, cons
 }
 
 
-#ifdef HAVE_CLAPACK_H
+#if defined HAVE_CLAPACK_H || defined HAVE_ATLAS_CLAPACK_H
 template <bool is_complex>
 inline void lauum(const enum CBLAS_ORDER order, const enum CBLAS_UPLO uplo, const int N, float* A, const int lda) {
   clapack_slauum(order, uplo, N, A, lda);
@@ -1019,7 +1025,7 @@ inline int potri(const enum CBLAS_ORDER order, const enum CBLAS_UPLO uplo, const
 }
 
 
-#ifdef HAVE_CLAPACK_H
+#if defined HAVE_CLAPACK_H || defined HAVE_ATLAS_CLAPACK_H
 template <>
 inline int potri(const enum CBLAS_ORDER order, const enum CBLAS_UPLO uplo, const int n, float* a, const int lda) {
   return clapack_spotri(order, uplo, n, a, lda);

--- a/ext/nmatrix/math/nrm2.h
+++ b/ext/nmatrix/math/nrm2.h
@@ -98,7 +98,7 @@ ReturnDType nrm2(const int N, const DType* X, const int incX) {
 }
 
 
-#ifdef HAVE_CBLAS_H
+#if defined HAVE_CBLAS_H || defined HAVE_ATLAS_CBLAS_H
 template <>
 inline float nrm2(const int N, const float* X, const int incX) {
   return cblas_snrm2(N, X, incX);

--- a/ext/nmatrix/math/potrs.h
+++ b/ext/nmatrix/math/potrs.h
@@ -60,7 +60,11 @@
 #define POTRS_H
 
 extern "C" {
+#if defined HAVE_CBLAS_H
   #include <cblas.h>
+#elif defined HAVE_ATLAS_CBLAS_H
+  #include <atlas/cblas.h>
+#endif
 }
 
 namespace nm { namespace math {

--- a/ext/nmatrix/math/trsm.h
+++ b/ext/nmatrix/math/trsm.h
@@ -60,7 +60,11 @@
 
 
 extern "C" {
+#if defined HAVE_CBLAS_H
   #include <cblas.h>
+#elif defined HAVE_ATLAS_CBLAS_H
+  #include <atlas/cblas.h>
+#endif
 }
 
 namespace nm { namespace math {

--- a/ext/nmatrix/nmatrix.cpp
+++ b/ext/nmatrix/nmatrix.cpp
@@ -31,12 +31,19 @@
  * Standard Includes
  */
 
-#include <cblas.h>
-#ifdef HAVE_CLAPACK_H
 extern "C" {
-  #include <clapack.h>
-}
+#if defined HAVE_CBLAS_H
+  #include <cblas.h>
+#elif defined HAVE_ATLAS_CBLAS_H
+  #include <atlas/cblas.h>
 #endif
+
+#if defined HAVE_CLAPACK_H
+  #include <clapack.h>
+#elif defined HAVE_ATLAS_CLAPACK_H
+  #include <atlas/clapack.h>
+#endif
+}
 
 #include <ruby.h>
 #include <algorithm> // std::min


### PR DESCRIPTION
This makes sure the correct cblas.h and clapack.h headers are chosen on
Debian and Ubuntu.
