### PR TITLE
Change transpose for 1D matrices to return a clone of the matrix instead...

### DIFF
--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -427,7 +427,9 @@ class NMatrix
   #   - A copy of the matrix, but transposed.
   #
   def transpose(permute = nil)
-    if self.dim <= 2 # This will give an error if dim is 1.
+    if self.dim == 1
+      return self.clone
+    elsif self.dim == 2
       new_shape = [self.shape[1], self.shape[0]]
     elsif permute.nil?
       raise(ArgumentError, "need permutation array of size #{self.dim}")

--- a/spec/00_nmatrix_spec.rb
+++ b/spec/00_nmatrix_spec.rb
@@ -439,6 +439,12 @@ describe "NMatrix#transpose" do
         n.transpose([1,0,2]).to_flat_array.should == [0,4,8,12,1,5,9,13,2,6,10,14,3,7,11,15]
         n.transpose([0,2,1]).to_flat_array.should == n.to_flat_array # for dense, make this reshape!
       end
+
+      it "should just copy a 1-dimensional #{stype} matrix" do
+        n = NMatrix.new([3], [1,2,3], stype: stype)
+        expect(n.transpose).to eq n
+        expect(n.transpose).not_to be n
+      end
     end
   end
 


### PR DESCRIPTION
... of segfault.

I also encountered #182 just on transposes and without any of the dot stuff in your example.

I chose cloning over raising an exception for consistency with what numpy does.  Note, though, that your testcase now raises an ArgumentError where it complains about incompatible dimensions when the dot product is taken.   (`m.dot(m)` in your example would also fail).  I'll open a separate issue about this.

Fixes #182.
