### PR TITLE
Add IRC notifications to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libatlas-base-dev
 script: bundle exec rake compile && bundle exec rake spec
-
+notifications:
+  irc: "chat.freenode.net#sciruby"


### PR DESCRIPTION
According to Travis' documentation[[1](http://docs.travis-ci.com/user/notifications/#IRC-notification)], this change should allow TravisCI to send build results notifications to the #sciruby channel.

I think this can be useful during GSoC.
