### PR TITLE
Remove pry and rspec-longrun from Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ gemspec
 gem 'packable', ">= 1.3.5"  # for Matlab IO
 
 group :development do
-  gem 'pry'
-  gem 'rspec-longrun'
   #gem 'narray', :path => "../narray"
   #gem 'pry-debugger'
 end


### PR DESCRIPTION
These are already listed in the gemspec as development dependencies and pulled into the Gemfile from there.

This stops a bundler warning about gems listed more than once.
