### PR TITLE
Added protection for out-of-bounds #rank calls

### DIFF
--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -352,6 +352,10 @@ class NMatrix
   #
   # See @row (dimension = 0), @column (dimension = 1)
   def rank(shape_idx, rank_idx, meth = :copy)
+    
+    if shape_idx > (self.dim-1)
+      raise(RangeError, "#rank call was out of bounds")
+    end
 
     params = Array.new(self.dim)
     params.each.with_index do |v,d|

--- a/spec/00_nmatrix_spec.rb
+++ b/spec/00_nmatrix_spec.rb
@@ -395,6 +395,18 @@ describe 'NMatrix' do
       expect(n.lower_triangle!(2)).to eq(NMatrix.new(4, [1,2,3,0,5,6,7,8,9,10,11,12,13,14,15,16]))
     end
   end
+  
+  context "#rank" do
+    it "should get the rank of a 2-dimensional matrix" do
+      n = NMatrix.seq([2,3])
+      expect(n.rank(0, 0)).to eq(N[[0,1,2]])
+    end
+    
+    it "should raise an error when the rank is out of bounds" do
+      n = NMatrix.seq([2,3])
+      expect { n.rank(2, 0) }.to raise_error(RangeError)
+    end
+  end
 
   context "#reshape" do
     it "should change the shape of a matrix without the contents changing" do


### PR DESCRIPTION
Referencing issue #227. Added some very rudimentary protection for out-of-bounds #rank calls, so that the user can't accidentally call a rank that doesn't exist. Before, there was no error, and it would just give you the largest rank.
