### PR TITLE
Update documentation (more than 95% coverage)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -207,7 +207,10 @@ end
 require "rdoc/task"
 RDoc::Task.new do |rdoc|
   rdoc.main = "README.rdoc"
-  rdoc.rdoc_files.include(%w{README.rdoc History.txt LICENSE.txt CONTRIBUTING.md ext/nmatrix/binary_format.txt lib/nmatrix/**/*.rb ext/nmatrix/**/*.cpp ext/nmatrix/**/*.c ext/nmatrix/**/*.h})
+  rdoc.rdoc_files.include(%w{README.rdoc History.txt LICENSE.txt CONTRIBUTING.md lib ext})
+  rdoc.options << "--exclude=ext/nmatrix/extconf.rb"
+  rdoc.options << "--exclude=ext/nmatrix/ttable_helper.rb"
+  rdoc.options << "--exclude=lib/nmatrix/rspec.rb"
 end
 
 # vim: syntax=ruby

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -123,7 +123,7 @@ def find_newer_gplusplus #:nodoc:
   false
 end
 
-def gplusplus_version #:nodoc:
+def gplusplus_version
   cxxvar = proc { |n| `#{CONFIG['CXX']} -E -dM - </dev/null | grep #{n}`.chomp.split(' ')[2] }
   major = cxxvar.call('__GNUC__')
   minor = cxxvar.call('__GNUC_MINOR__')
@@ -211,7 +211,7 @@ end
 
 # Although have_func is supposed to take a list as its second argument, I find that it simply
 # applies a :to_s to the second arg and doesn't actually check each one. We may want to put
-# have_func calls inside an :each block which checks atlas/clapack.h, cblas.h, clapack.h, and 
+# have_func calls inside an :each block which checks atlas/clapack.h, cblas.h, clapack.h, and
 # lastly lapack.h. On Ubuntu, it only works if I use atlas/clapack.h. --@mohawkjohn 8/20/14
 have_func("clapack_dgetrf", "atlas/clapack.h")
 have_func("clapack_dgetri", "atlas/clapack.h")

--- a/ext/nmatrix/ruby_constants.cpp
+++ b/ext/nmatrix/ruby_constants.cpp
@@ -148,7 +148,6 @@ void nm_init_ruby_constants(void) {
 	nm_rb_column            = rb_intern("column");
 	nm_rb_row               = rb_intern("row");
 
-  //Added by Ryan
   nm_rb_both              = rb_intern("both");
   nm_rb_none              = rb_intern("none");
 }

--- a/ext/nmatrix/ruby_nmatrix.c
+++ b/ext/nmatrix/ruby_nmatrix.c
@@ -208,6 +208,7 @@ void Init_nmatrix() {
   nm_eNotInvertibleError = rb_define_class("NotInvertibleError", rb_eStandardError);
 
   /*
+   * :nodoc:
    * Class that holds values in use by the C code.
    */
   cNMatrix_GC_holder = rb_define_class("NMGCHolder", rb_cObject);

--- a/ext/nmatrix/storage/yale/yale.cpp
+++ b/ext/nmatrix/storage/yale/yale.cpp
@@ -549,7 +549,7 @@ static char vector_insert_resize(YALE_STORAGE* s, size_t current_size, size_t po
   NM_FREE(s->ija);
   nm_yale_storage_unregister(s);
   NM_FREE(s->a);
-  
+
   if (s->dtype == nm::RUBYOBJ)
     nm_yale_storage_unregister_a(new_a, new_capacity);
 
@@ -943,7 +943,7 @@ static VALUE map_stored(VALUE self) {
   NM_CONSERVATIVE(nm_register_value(&self));
   YALE_STORAGE* s = NM_STORAGE_YALE(self);
   YaleStorage<D> y(s);
-  
+
   RETURN_SIZED_ENUMERATOR_PRE
   NM_CONSERVATIVE(nm_unregister_value(&self));
   RETURN_SIZED_ENUMERATOR(self, 0, 0, nm_yale_stored_enumerator_length);
@@ -1014,7 +1014,7 @@ static VALUE stored_diagonal_each_with_indices(VALUE nm) {
   RETURN_SIZED_ENUMERATOR_PRE
   NM_CONSERVATIVE(nm_unregister_value(&nm));
   RETURN_SIZED_ENUMERATOR(nm, 0, 0, nm_yale_stored_diagonal_length); // FIXME: need diagonal length
-  
+
   for (typename YaleStorage<DType>::const_stored_diagonal_iterator d = y.csdbegin(); d != y.csdend(); ++d) {
     rb_yield_values(3, ~d, d.rb_i(), d.rb_j());
   }
@@ -1106,9 +1106,7 @@ static bool is_pos_default_value(YALE_STORAGE* s, size_t apos) {
   return y.is_pos_default_value(apos);
 }
 
-
 } // end of namespace nm::yale_storage
-
 
 } // end of namespace nm.
 
@@ -1123,7 +1121,7 @@ extern "C" {
 void nm_init_yale_functions() {
 	/*
 	 * This module stores methods that are useful for debugging Yale matrices,
-	 * i.e. the ones with +:yale+ stype.	
+	 * i.e. the ones with +:yale+ stype.
 	 */
   cNMatrix_YaleFunctions = rb_define_module_under(cNMatrix, "YaleFunctions");
 
@@ -1141,10 +1139,13 @@ void nm_init_yale_functions() {
 
   rb_define_method(cNMatrix_YaleFunctions, "yale_nd_row", (METHOD)nm_nd_row, -1);
 
+  /* Document-const:
+   * Defines the growth rate of the sparse NMatrix's size. Default is 1.5.
+   */
   rb_define_const(cNMatrix_YaleFunctions, "YALE_GROWTH_CONSTANT", rb_float_new(nm::yale_storage::GROWTH_CONSTANT));
 
   // This is so the user can easily check the IType size, mostly for debugging.
-  size_t itype_size        = sizeof(IType);
+  size_t itype_size = sizeof(IType);
   VALUE itype_dtype;
   if (itype_size == sizeof(uint64_t)) {
     itype_dtype = ID2SYM(rb_intern("int64"));
@@ -1158,11 +1159,9 @@ void nm_init_yale_functions() {
   rb_define_const(cNMatrix, "INDEX_DTYPE", itype_dtype);
 }
 
-
 /////////////////
 // C ACCESSORS //
 /////////////////
-
 
 /* C interface for NMatrix#each_with_indices (Yale) */
 VALUE nm_yale_each_with_indices(VALUE nmatrix) {
@@ -1555,7 +1554,7 @@ static bool is_pos_default_value(YALE_STORAGE* s, size_t apos) {
  * Only checks the stored indices; does not care about matrix default value.
  */
 static VALUE nm_row_keys_intersection(VALUE m1, VALUE ii1, VALUE m2, VALUE ii2) {
-  
+
   NM_CONSERVATIVE(nm_register_value(&m1));
   NM_CONSERVATIVE(nm_register_value(&m2));
 
@@ -1658,7 +1657,7 @@ static VALUE nm_a(int argc, VALUE* argv, VALUE self) {
     VALUE* vals = NM_ALLOCA_N(VALUE, size);
 
     nm_register_values(vals, size);
-    
+
     if (NM_DTYPE(self) == nm::RUBYOBJ) {
       for (size_t i = 0; i < size; ++i) {
         vals[i] = reinterpret_cast<VALUE*>(s->a)[i];
@@ -1786,7 +1785,7 @@ static VALUE nm_ia(VALUE self) {
     vals[i] = INT2FIX(s->ija[i]);
   }
 
-  NM_CONSERVATIVE(nm_unregister_value(&self)); 
+  NM_CONSERVATIVE(nm_unregister_value(&self));
 
   return rb_ary_new4(s->shape[0]+1, vals);
 }
@@ -1887,11 +1886,10 @@ static VALUE nm_ija(int argc, VALUE* argv, VALUE self) {
 static VALUE nm_nd_row(int argc, VALUE* argv, VALUE self) {
 
   NM_CONSERVATIVE(nm_register_value(&self));
-  
   if (NM_SRC(self) != NM_STORAGE(self)) {
     NM_CONSERVATIVE(nm_unregister_value(&self));
     rb_raise(rb_eNotImpError, "must be called on a real matrix and not a slice");
-  }  
+  }
 
   VALUE i_, as;
   rb_scan_args(argc, argv, "11", &i_, &as);

--- a/ext/nmatrix/ttable_helper.rb
+++ b/ext/nmatrix/ttable_helper.rb
@@ -2,7 +2,6 @@
 
 # A helper file for generating and maintaining template tables.
 
-
 DTYPES = [
           :uint8_t,
           :int8_t,

--- a/lib/nmatrix.rb
+++ b/lib/nmatrix.rb
@@ -34,6 +34,11 @@ else
   require "nmatrix.so"
 end
 
+require 'nmatrix/io/mat_reader'
+require 'nmatrix/io/mat5_reader'
+require 'nmatrix/io/market'
+require 'nmatrix/io/point_cloud'
+
 require 'nmatrix/nmatrix.rb'
 require 'nmatrix/version.rb'
 require 'nmatrix/blas.rb'

--- a/lib/nmatrix/io/market.rb
+++ b/lib/nmatrix/io/market.rb
@@ -26,30 +26,42 @@
 #
 #++
 
+# Matrix Market is a repository of test data for use in studies of algorithms
+# for numerical linear algebra. There are 3 file formats used:
+#
+# - Matrix Market Exchange Format.
+# - Harwell-Boeing Exchange Format.
+# - Coordinate Text File Format. (to be phased out)
+#
+# This module can load and save the first format. We might support
+# Harwell-Boeing in the future.
+#
+# The MatrixMarket format is documented in:
+# * http://math.nist.gov/MatrixMarket/formats.html
 module NMatrix::IO::Market
   CONVERTER_AND_DTYPE = {
     :real => [:to_f, :float64],
     :complex => [:to_c, :complex128],
     :integer => [:to_i, :int64],
     :pattern => [:to_i, :byte]
-  }
+  } #:nodoc:
 
   ENTRY_TYPE = {
     :byte => :integer, :int8 => :integer, :int16 => :integer, :int32 => :integer, :int64 => :integer,
     :float32 => :real, :float64 => :real, :complex64 => :complex, :complex128 => :complex
-  }
+  } #:nodoc:
 
   class << self
-    #
+
     # call-seq:
-    #     load(filename) ->
+    #     load(filename) -> NMatrix
+    #
+    # Load a MatrixMarket file. Requires a +filename+ as an argument.
     #
     # * *Arguments* :
     #   - +filename+ -> String with the filename to be saved.
     # * *Raises* :
     #   - +IOError+ -> expected type code line beginning with '%%MatrixMarket matrix'
-    #
-    # Load a MatrixMarket file. Requires a filename as an argument.
     def load(filename)
 
       f = File.new(filename, "r")
@@ -71,7 +83,6 @@ module NMatrix::IO::Market
       end
     end
 
-    #
     # call-seq:
     #     save(matrix, filename, options = {}) -> true
     #
@@ -85,7 +96,6 @@ module NMatrix::IO::Market
     # * *Raises* :
     #   - +DataTypeError+ -> MatrixMarket does not support rational or Ruby objects.
     #   - +ArgumentError+ -> Expected two-dimensional NMatrix.
-    #
     def save(matrix, filename, options = {})
       options = {:pattern => false,
         :symmetry => :general}.merge(options)

--- a/lib/nmatrix/io/mat_reader.rb
+++ b/lib/nmatrix/io/mat_reader.rb
@@ -30,13 +30,12 @@
 require 'packable'
 
 module NMatrix::IO::Matlab
-  #
+
   # Class for parsing a .mat file stream.
   #
   # The full format of .mat files is available here:
   # * http://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf
-  #
-  class MatReader
+  class MatReader #:nodoc:
     MDTYPE_UNPACK_ARGS = {
       :miINT8   => [Integer, {:signed    => true,    :bytes => 1}],
       :miUINT8  => [Integer, {:signed    => false,   :bytes => 1}],
@@ -146,7 +145,7 @@ module NMatrix::IO::Matlab
 
     attr_reader :byte_order
 
-    #
+
     # call-seq:
     #     new(stream, options = {}) -> MatReader
     #
@@ -160,7 +159,6 @@ module NMatrix::IO::Matlab
       @byte_order = options[:byte_order] || guess_byte_order
     end
 
-    #
     # call-seq:
     #     guess_byte_order -> Symbol
     #

--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -30,7 +30,7 @@
 
 class NMatrix
 
-  module NMMath
+  module NMMath #:nodoc:
     METHODS_ARITY_2 = [:atan2, :ldexp, :hypot]
     METHODS_ARITY_1 = [:cos, :sin, :tan, :acos, :asin, :atan, :cosh, :sinh, :tanh, :acosh,
       :asinh, :atanh, :exp, :log2, :log10, :sqrt, :cbrt, :erf, :erfc, :gamma, :-@]
@@ -182,7 +182,7 @@ class NMatrix
   #     gesvd! -> [u, sigma, v_transpose]
   #     gesvd! -> [u, sigma, v_conjugate_transpose] # complex
   #
-  # Compute the singular value decomposition of a matrix using LAPACK's GESVD function. 
+  # Compute the singular value decomposition of a matrix using LAPACK's GESVD function.
   # This is destructive, modifying the source NMatrix.  See also #gesdd.
   #
   # Optionally accepts a +workspace_size+ parameter, which will be honored only if it is larger than what LAPACK
@@ -589,7 +589,8 @@ protected
 
   # These don't actually take an argument -- they're called reverse-polish style on the matrix.
   # This group always gets casted to float64.
-  [:log, :log2, :log10, :sqrt, :sin, :cos, :tan, :acos, :asin, :atan, :cosh, :sinh, :tanh, :acosh, :asinh, :atanh, :exp, :erf, :erfc, :gamma, :cbrt].each do |ewop|
+  [:log, :log2, :log10, :sqrt, :sin, :cos, :tan, :acos, :asin, :atan, :cosh, :sinh, :tanh, :acosh,
+   :asinh, :atanh, :exp, :erf, :erfc, :gamma, :cbrt].each do |ewop|
     define_method("__list_unary_#{ewop}__") do
       self.__list_map_stored__(nil) { |l| Math.send(ewop, l) }.cast(stype, NMatrix.upcast(dtype, :float64))
     end
@@ -601,7 +602,8 @@ protected
     end
   end
 
-  # log takes an optional single argument, the base.  Default to natural log.
+  #:stopdoc:
+  # log takes an optional single argument, the base. Default to natural log.
   def __list_unary_log__(base)
     self.__list_map_stored__(nil) { |l| Math.log(l, base) }.cast(stype, NMatrix.upcast(dtype, :float64))
   end
@@ -626,6 +628,7 @@ protected
   def __dense_unary_negate__
     self.__dense_map__ { |l| -l }.cast(stype, dtype)
   end
+  #:startdoc:
 
   # These are for calculating the floor or ceil of matrix
   def dtype_for_floor_or_ceil
@@ -638,36 +641,36 @@ protected
     return_dtype
   end
 
-  [:floor, :ceil].each do |meth|  
+  [:floor, :ceil].each do |meth|
     define_method("__list_unary_#{meth}__") do
       return_dtype = dtype_for_floor_or_ceil
 
       if [:complex64, :complex128].include?(self.dtype)
-        self.__list_map_stored__(nil) { |l| Complex(l.real.send(meth), l.imag.send(meth)) }.cast(stype, return_dtype) 
+        self.__list_map_stored__(nil) { |l| Complex(l.real.send(meth), l.imag.send(meth)) }.cast(stype, return_dtype)
       else
-        self.__list_map_stored__(nil) { |l| l.send(meth) }.cast(stype, return_dtype)   
+        self.__list_map_stored__(nil) { |l| l.send(meth) }.cast(stype, return_dtype)
       end
     end
-    
-    define_method("__yale_unary_#{meth}__") do 
+
+    define_method("__yale_unary_#{meth}__") do
       return_dtype = dtype_for_floor_or_ceil
 
       if [:complex64, :complex128].include?(self.dtype)
-        self.__yale_map_stored__ { |l| Complex(l.real.send(meth), l.imag.send(meth)) }.cast(stype, return_dtype) 
+        self.__yale_map_stored__ { |l| Complex(l.real.send(meth), l.imag.send(meth)) }.cast(stype, return_dtype)
       else
-        self.__yale_map_stored__ { |l| l.send(meth) }.cast(stype, return_dtype)   
+        self.__yale_map_stored__ { |l| l.send(meth) }.cast(stype, return_dtype)
       end
     end
-    
+
     define_method("__dense_unary_#{meth}__") do
       return_dtype = dtype_for_floor_or_ceil
-       
+
       if [:complex64, :complex128].include?(self.dtype)
-        self.__dense_map__ { |l| Complex(l.real.send(meth), l.imag.send(meth)) }.cast(stype, return_dtype) 
+        self.__dense_map__ { |l| Complex(l.real.send(meth), l.imag.send(meth)) }.cast(stype, return_dtype)
       else
-        self.__dense_map__ { |l| l.send(meth) }.cast(stype, return_dtype)   
+        self.__dense_map__ { |l| l.send(meth) }.cast(stype, return_dtype)
       end
-    end     
+    end
   end
 
   # These take two arguments. One might be a matrix, and one might be a scalar.

--- a/lib/nmatrix/monkeys.rb
+++ b/lib/nmatrix/monkeys.rb
@@ -100,7 +100,7 @@ class Object #:nodoc:
 end
 
 
-module Math
+module Math #:nodoc:
   class << self
     NMatrix::NMMath::METHODS_ARITY_2.each do |meth|
       define_method "nm_#{meth}" do |arg0, arg1|

--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -32,16 +32,29 @@ require_relative './lapack.rb'
 require_relative './yale_functions.rb'
 require_relative './monkeys'
 
-
+# NMatrix is a matrix class that supports both multidimensional arrays
+# (`:dense` stype) and sparse storage (`:list` or `:yale` stypes) and 13 data
+# types, including complex and rational numbers, various integer and
+# floating-point sizes and ruby objects.
 class NMatrix
+  # Read and write extensions for NMatrix.
   module IO
     extend AutoloadPatch
 
+    # Reader (and eventually writer) of Matlab .mat files.
+    #
+    # The .mat file format is documented in the following link:
+    # * http://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf
     module Matlab
       extend AutoloadPatch
 
       class << self
-        def load_mat file_path
+        # call-seq:
+        #     load(mat_file_path) -> NMatrix
+        #     load_mat(mat_file_path) -> NMatrix
+        #
+        # Load a .mat file and return a NMatrix corresponding to it.
+        def load_mat(file_path)
           NMatrix::IO::Matlab::Mat5Reader.new(File.open(file_path, "rb+")).to_ruby
         end
         alias :load :load_mat
@@ -50,7 +63,6 @@ class NMatrix
   end
 
   class << self
-    #
     # call-seq:
     #     load_matlab_file(path) -> Mat5Reader
     #
@@ -58,12 +70,10 @@ class NMatrix
     #   - +file_path+ -> The path to a version 5 .mat file.
     # * *Returns* :
     #   - A Mat5Reader object.
-    #
     def load_matlab_file(file_path)
       NMatrix::IO::Mat5Reader.new(File.open(file_path, 'rb')).to_ruby
     end
 
-    #
     # call-seq:
     #     load_pcd_file(path) -> PointCloudReader::MetaReader
     #
@@ -71,12 +81,10 @@ class NMatrix
     #   - +file_path+ -> The path to a PCL PCD file.
     # * *Returns* :
     #   - A PointCloudReader::MetaReader object with the matrix stored in its +matrix+ property
-    #
     def load_pcd_file(file_path)
       NMatrix::IO::PointCloudReader::MetaReader.new(file_path)
     end
 
-    #
     # Calculate the size of an NMatrix of a given shape.
     def size(shape)
       shape = [shape,shape] unless shape.is_a?(Array)
@@ -124,8 +132,6 @@ class NMatrix
       end
     end
   end
-  #alias :pp :pretty_print
-
 
   #
   # call-seq:
@@ -234,7 +240,6 @@ class NMatrix
   end
 
 
-  ##
   # call-seq:
   #   integer_dtype?() -> Boolean
   #
@@ -348,7 +353,7 @@ class NMatrix
   #
   # See @row (dimension = 0), @column (dimension = 1)
   def rank(shape_idx, rank_idx, meth = :copy)
-    
+
     if shape_idx > (self.dim-1)
       raise(RangeError, "#rank call was out of bounds")
     end
@@ -508,7 +513,6 @@ class NMatrix
   end
 
 
-  #
   # call-seq:
   #     matrix1.concat(*m2) -> NMatrix
   #     matrix1.concat(*m2, rank) -> NMatrix
@@ -516,20 +520,21 @@ class NMatrix
   #     matrix1.vconcat(*m2) -> NMatrix
   #     matrix1.dconcat(*m3) -> NMatrix
   #
-  # Joins two matrices together into a new larger matrix. Attempts to determine which direction to concatenate
-  # on by looking for the first common element of the matrix +shape+ in reverse. In other words, concatenating two
-  # columns together without supplying +rank+ will glue them into an n x 2 matrix.
+  # Joins two matrices together into a new larger matrix. Attempts to determine
+  # which direction to concatenate on by looking for the first common element
+  # of the matrix +shape+ in reverse. In other words, concatenating two columns
+  # together without supplying +rank+ will glue them into an n x 2 matrix.
   #
-  # You can also use hconcat, vconcat, and dconcat for the first three ranks. concat performs an hconcat when no
-  # rank argument is provided.
+  # You can also use hconcat, vconcat, and dconcat for the first three ranks.
+  # concat performs an hconcat when no rank argument is provided.
   #
   # The two matrices must have the same +dim+.
   #
   # * *Arguments* :
   #   - +matrices+ -> one or more matrices
-  #   - +rank+ -> Fixnum (for rank); alternatively, may use :row, :column, or :layer for 0, 1, 2, respectively
-  #
-  def concat *matrices
+  #   - +rank+ -> Fixnum (for rank); alternatively, may use :row, :column, or
+  #   :layer for 0, 1, 2, respectively
+  def concat(*matrices)
     rank = nil
     rank = matrices.pop unless matrices.last.is_a?(NMatrix)
 
@@ -583,15 +588,18 @@ class NMatrix
     n
   end
 
-  def hconcat *matrices
+  # Horizontal concatenation with +matrices+.
+  def hconcat(*matrices)
     concat(*matrices, :column)
   end
 
-  def vconcat *matrices
+  # Vertical concatenation with +matrices+.
+  def vconcat(*matrices)
     concat(*matrices, :row)
   end
 
-  def dconcat *matrices
+  # Depth concatenation with +matrices+.
+  def dconcat(*matrices)
     concat(*matrices, :layer)
   end
 

--- a/lib/nmatrix/rspec.rb
+++ b/lib/nmatrix/rspec.rb
@@ -29,7 +29,7 @@
 require 'rspec'
 
 # Amend RSpec to allow #be_within for matrices.
-module RSpec::Matchers::BuiltIn #:nodoc:
+module RSpec::Matchers::BuiltIn
   class BeWithin
 
     def of(expected)

--- a/lib/nmatrix/shortcuts.rb
+++ b/lib/nmatrix/shortcuts.rb
@@ -34,29 +34,40 @@
 
 class NMatrix
 
-
-
-  #
   # call-seq:
-  #     dense? -> true or false
-  #     list? -> true or false
-  #     yale? -> true or false
+  #     m.dense? -> true or false
   #
-  # Shortcut functions for quickly determining a matrix's stype.
-  #
+  # Determine if +m+ is a dense matrix.
   def dense?; return stype == :dense; end
-  def yale?;  return stype == :yale;  end
-  def list?;  return stype == :list;  end
 
+  # call-seq:
+  #     m.yale? -> true or false
+  #
+  # Determine if +m+ is a Yale matrix.
+  def yale?;  return stype == :yale; end
+
+  # call-seq:
+  #     m.list? -> true or false
+  #
+  # Determine if +m+ is a list-of-lists matrix.
+  def list?;  return stype == :list; end
 
   class << self
-    #
     # call-seq:
-    #     NMatrix[array-of-arrays, dtype = nil]
+    #     NMatrix[Numeric, ..., Numeric, dtype: Symbol] -> NMatrix
+    #     NMatrix[Array, dtype: Symbol] -> NMatrix
     #
-    # You can use the old +N+ constant in this way:
+    # The default value for +dtype+ is guessed from the first parameter. For example:
+    #   NMatrix[1.0, 2.0].dtype # => :float64
+    #   NMatrix[1r, 2r].dtype   # => :rational64
+    #
+    # But this is just a *guess*. If the other values can't be converted to
+    # this dtype, a +TypeError+ will be raised.
+    #
+    # You can use the +N+ constant in this way:
     #   N = NMatrix
     #   N[1, 2, 3]
+    #
     # NMatrix needs to have a succinct way to create a matrix by specifying the
     # components directly. This is very useful for using it as an advanced
     # calculator, it is useful for learning how to use, for testing language
@@ -68,12 +79,16 @@ class NMatrix
     #
     # Examples:
     #
-    #   a = NMatrix[ 1,2,3,4 ]          =>  1.0  2.0  3.0  4.0
+    #   a = N[ 1,2,3,4 ]          =>  1  2  3  4
     #
-    #   a = NMatrix[ 1,2,3,4, dtype: :int32 ]  =>  1  2  3  4
+    #   a = N[ 1,2,3,4, :int32 ]  =>  1  2  3  4
     #
-    #   a = NMatrix[ [1,2,3], [3,4,5] ] =>  1.0  2.0  3.0
-    #                                       3.0  4.0  5.0
+    #   a = N[ [1,2,3], [3,4,5] ] =>  1.0  2.0  3.0
+    #                                 3.0  4.0  5.0
+    #
+    #   a = N[ 3,6,9 ].transpose => 3
+    #                               6
+    #                               9
     #
     # SYNTAX COMPARISON:
     #
@@ -83,7 +98,6 @@ class NMatrix
     #
     #   SciRuby:      a = NMatrix[ [1,2,3], [4,5,6] ]
     #   Ruby array:   a =  [ [1,2,3], [4,5,6] ]
-    #
     def [](*params)
       options = params.last.is_a?(Hash) ? params.pop : {}
 
@@ -159,7 +173,6 @@ class NMatrix
       NMatrix.new(shape, 1, {:dtype => :float64, :default => 1}.merge(opts))
     end
 
-    ##
     # call-seq:
     #   ones_like(nm) -> NMatrix
     #
@@ -173,7 +186,6 @@ class NMatrix
       NMatrix.ones(nm.shape, dtype: nm.dtype, stype: nm.stype, capacity: nm.capacity, default: 1)
     end
 
-    ##
     # call-seq:
     #   zeros_like(nm) -> NMatrix
     #
@@ -355,7 +367,7 @@ class NMatrix
   end
 end
 
-module NVector
+module NVector #:nodoc:
 
   class << self
     #
@@ -648,14 +660,19 @@ module NVector
 end
 
 
-# Use this constant as you would use NMatrix[].
+# This constant is intended as a simple constructor for NMatrix meant for
+# experimenting.
+#
 # Examples:
 #
-#   a = N[ 1,2,3,4 ]          =>  1.0  2.0  3.0  4.0
+#   a = N[ 1,2,3,4 ]          =>  1  2  3  4
 #
 #   a = N[ 1,2,3,4, :int32 ]  =>  1  2  3  4
 #
-#   a = N[ [1,2,3], [3,4,5] ] =>  1.0  2.0  3.0
-#                                 3.0  4.0  5.0
+#   a = N[ [1,2,3], [3,4,5] ] =>  1  2  3
+#                                 3  4  5
 #
+#   a = N[ 3,6,9 ].transpose => 3
+#                               6
+#                               9
 N = NMatrix

--- a/lib/nmatrix/version.rb
+++ b/lib/nmatrix/version.rb
@@ -26,8 +26,7 @@ class NMatrix
   # Note that the format of the VERSION string is needed for NMatrix
   # native IO. If you change the format, please make sure that native
   # IO can still understand NMatrix::VERSION.
-  #VERSION = "0.1.0"
-  module VERSION
+  module VERSION #:nodoc:
     MAJOR = 0
     MINOR = 1
     TINY = 0


### PR DESCRIPTION
Some changes in this pull request aren't strictly documentation (i.e. how to use a method or class), but:
- Simplify documentation processing (e.g. excluding files in the RDoc task); or
- Hide certain methods and classes from the generated documentation with `:nodoc:`.

The latter is useful because there is a lot of information (e.g. `NMatrix::IO::Matlab::Mat5Reader` internals) that shouldn't appear on public API documentation. Also, I added or updated "real" documentation for shortcuts, NMatrix::IO modules and classes and others.

Another minor change that I did is removing `autoloads` in NMatrix::IO. Apart from a `FIXME` asking for it explicitly, the speed gain should be negligible and it improves the organization of the files (it's easier to know what's being required).

I sent a pull request to the sciruby.com repository with the docs generated with this pull request: [#6 Update NMatrix documentation](https://github.com/SciRuby/sciruby.com/pull/6).
