### PR TITLE
Remove unused Guardfile

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,0 @@
-guard 'rspec' do
-  watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$}) { "spec" }
-  watch(%r{^ext/nmatrix/(.+)\.(c|cpp|h|rb)$}) { `rake compile | rake spec` }
-  watch('spec/spec_helper.rb')  { "spec" }
-end


### PR DESCRIPTION
- `guard-rspec` isn't being included within the project, so we ought to
  remove this file.
