### PR TITLE
Gemfile: remove unused dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,3 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'packable', ">= 1.3.5"  # for Matlab IO
-
-group :development do
-  #gem 'narray', :path => "../narray"
-  #gem 'pry-debugger'
-end


### PR DESCRIPTION
The point of calling `gemspec` is to tell bundle that the dependencies are listed in there so I think really none of these dependencies should be here but got rid of the commented out ones and left `gem 'packable', ">= 1.3.5"  # for Matlab IO` since they are clearly not doing anything and I did not want to have to search out the versioning to add packable to gemspec. :-)
