### PR TITLE
Temporary (?) fix for NMatrix#gesdd

### DIFF
--- a/lib/nmatrix/lapack.rb
+++ b/lib/nmatrix/lapack.rb
@@ -168,7 +168,9 @@ class NMatrix
       # Optionally accepts a +workspace_size+ parameter, which will be honored only if it is larger than what LAPACK
       # requires.
       #
-      def gesdd(matrix, workspace_size=100000)
+      def gesdd(matrix, workspace_size=nil)
+        min_workspace_size = matrix.shape.min * (6 + 4 * matrix.shape.min) + matrix.shape.max
+        workspace_size = min_workspace_size if workspace_size.nil? || workspace_size < min_workspace_size
         result = alloc_svd_result(matrix)
         NMatrix::LAPACK::lapack_gesdd(:a, matrix.shape[0], matrix.shape[1], matrix, matrix.shape[0], result[1], result[0], matrix.shape[0], result[2], matrix.shape[1], workspace_size)
         result

--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -219,7 +219,7 @@ class NMatrix
   # Optionally accepts a +workspace_size+ parameter, which will be honored only if it is larger than what LAPACK
   # requires.
   #
-  def gesdd!(workspace_size=1)
+  def gesdd!(workspace_size=nil)
     NMatrix::LAPACK::gesdd(self, workspace_size)
   end
 
@@ -234,7 +234,7 @@ class NMatrix
   # Optionally accepts a +workspace_size+ parameter, which will be honored only if it is larger than what LAPACK
   # requires.
   #
-  def gesdd(workspace_size=1)
+  def gesdd(workspace_size=nil)
     self.clone.gesdd!(workspace_size)
   end
   #


### PR DESCRIPTION
This should fix #211.

It seems that the workspace_size parameter is causing NMatrix#gesdd to fail. In NMatrix::LAPACK::gesdd the default workspace_size parameter is 100000, but is only 1 on NMatrix#gesdd. 

Making it consistent appears to get it working, but I can't help but think 100000 is kind of arbitrary. Was there a special reason 100000 was made the default value? And if we had a matrix that requires something larger than that would this fail? 

Perhaps this needs to be revisited, but for now this patch should get it working at least.
