### PR TITLE
Use address rather than value in several conservative registrations.

### DIFF
--- a/ext/nmatrix/ruby_nmatrix.c
+++ b/ext/nmatrix/ruby_nmatrix.c
@@ -741,7 +741,7 @@ static VALUE nm_each_with_indices(VALUE nmatrix) {
     to_return = nm_list_each_with_indices(nmatrix, false);
     break;
   default:
-    NM_CONSERVATIVE(nm_unregister_value(nmatrix));
+    NM_CONSERVATIVE(nm_unregister_value(&nmatrix));
     rb_raise(nm_eDataTypeError, "Not a proper storage type");
   }
 


### PR DESCRIPTION
While doing some debugging for #277, I compiled with `NM_GC_CONSERVATIVE` defined, and found that the code no longer compiled!  This was due to a number of places where I was unregistering a value instead of a pointer.  I've fixed this by passing addresses instead, which allows nmatrix to compile with the conservative gc flag on.
