### PR TITLE
Fix deprecated RSpec code

### DIFF
--- a/spec/00_nmatrix_spec.rb
+++ b/spec/00_nmatrix_spec.rb
@@ -525,7 +525,7 @@ describe 'NMatrix' do
     [:dense, :yale, :list].each do |stype|
       context(stype) do
         it "should work in-place for complex dtypes" do
-          pending("not yet implemented for list stype") if stype == :list
+          skip("not yet implemented for list stype") if stype == :list
           n = NMatrix.new([2,3], [Complex(2,3)], stype: stype, dtype: :complex128)
           n.complex_conjugate!
           expect(n).to eq(NMatrix.new([2,3], [Complex(2,-3)], stype: stype, dtype: :complex128))
@@ -533,7 +533,7 @@ describe 'NMatrix' do
 
         [:object, :int64].each do |dtype|
           it "should work in-place for non-complex dtypes" do
-            pending("not yet implemented for list stype") if stype == :list
+            skip("not yet implemented for list stype") if stype == :list
             n = NMatrix.new([2,3], 1, stype: stype, dtype: dtype)
             n.complex_conjugate!
             expect(n).to eq(NMatrix.new([2,3], [1], stype: stype, dtype: dtype))
@@ -547,14 +547,14 @@ describe 'NMatrix' do
     [:dense, :yale, :list].each do |stype|
       context(stype) do
         it "should work out-of-place for complex dtypes" do
-          pending("not yet implemented for list stype") if stype == :list
+          skip("not yet implemented for list stype") if stype == :list
           n = NMatrix.new([2,3], [Complex(2,3)], stype: stype, dtype: :complex128)
           expect(n.complex_conjugate).to eq(NMatrix.new([2,3], [Complex(2,-3)], stype: stype, dtype: :complex128))
         end
 
         [:object, :int64].each do |dtype|
           it "should work out-of-place for non-complex dtypes" do
-            pending("not yet implemented for list stype") if stype == :list
+            skip("not yet implemented for list stype") if stype == :list
             n = NMatrix.new([2,3], 1, stype: stype, dtype: dtype)
             expect(n.complex_conjugate).to eq(NMatrix.new([2,3], [1], stype: stype, dtype: dtype))
           end

--- a/spec/02_slice_spec.rb
+++ b/spec/02_slice_spec.rb
@@ -127,9 +127,9 @@ describe "Slice operation" do
       it "should have #is_ref? method" do
         a = stype_matrix[0..1, 0..1]
         b = stype_matrix.slice(0..1, 0..1)
-        expect(stype_matrix.is_ref?).to be_false
-        expect(a.is_ref?).to be_true
-        expect(b.is_ref?).to be_false
+        expect(stype_matrix.is_ref?).to be_falsey
+        expect(a.is_ref?).to be_truthy
+        expect(b.is_ref?).to be_falsey
       end
 
       it "reference should compare with non-reference" do
@@ -141,7 +141,7 @@ describe "Slice operation" do
       context "with copying" do
         it 'should return an NMatrix' do
           n = stype_matrix.slice(0..1,0..1)
-          expect(nm_eql(n, NMatrix.new([2,2], [0,1,3,4], dtype: :int32))).to be_true
+          expect(nm_eql(n, NMatrix.new([2,2], [0,1,3,4], dtype: :int32))).to be_truthy
         end
 
         it 'should return a copy of 2x2 matrix to self elements' do
@@ -183,19 +183,19 @@ describe "Slice operation" do
 
         [:dense, :list, :yale].each do |cast_type|
           it "should cast copied slice from #{stype.upcase} to #{cast_type.upcase}" do
-            expect(nm_eql(stype_matrix.slice(1..2, 1..2).cast(cast_type, :int32), stype_matrix.slice(1..2,1..2))).to be_true
-            expect(nm_eql(stype_matrix.slice(0..1, 1..2).cast(cast_type, :int32), stype_matrix.slice(0..1,1..2))).to be_true
-            expect(nm_eql(stype_matrix.slice(1..2, 0..1).cast(cast_type, :int32), stype_matrix.slice(1..2,0..1))).to be_true
-            expect(nm_eql(stype_matrix.slice(0..1, 0..1).cast(cast_type, :int32), stype_matrix.slice(0..1,0..1))).to be_true
+            expect(nm_eql(stype_matrix.slice(1..2, 1..2).cast(cast_type, :int32), stype_matrix.slice(1..2,1..2))).to be_truthy
+            expect(nm_eql(stype_matrix.slice(0..1, 1..2).cast(cast_type, :int32), stype_matrix.slice(0..1,1..2))).to be_truthy
+            expect(nm_eql(stype_matrix.slice(1..2, 0..1).cast(cast_type, :int32), stype_matrix.slice(1..2,0..1))).to be_truthy
+            expect(nm_eql(stype_matrix.slice(0..1, 0..1).cast(cast_type, :int32), stype_matrix.slice(0..1,0..1))).to be_truthy
 
             # Non square
-            expect(nm_eql(stype_matrix.slice(0..2, 1..2).cast(cast_type, :int32), stype_matrix.slice(0..2,1..2))).to be_true
+            expect(nm_eql(stype_matrix.slice(0..2, 1..2).cast(cast_type, :int32), stype_matrix.slice(0..2,1..2))).to be_truthy
             #require 'pry'
             #binding.pry if cast_type == :yale
-            expect(nm_eql(stype_matrix.slice(1..2, 0..2).cast(cast_type, :int32), stype_matrix.slice(1..2,0..2))).to be_true
+            expect(nm_eql(stype_matrix.slice(1..2, 0..2).cast(cast_type, :int32), stype_matrix.slice(1..2,0..2))).to be_truthy
 
             # Full
-            expect(nm_eql(stype_matrix.slice(0..2, 0..2).cast(cast_type, :int32), stype_matrix)).to be_true
+            expect(nm_eql(stype_matrix.slice(0..2, 0..2).cast(cast_type, :int32), stype_matrix)).to be_truthy
           end
         end
       end
@@ -214,7 +214,7 @@ describe "Slice operation" do
       context "by reference" do
         it 'should return an NMatrix' do
           n = stype_matrix[0..1,0..1]
-          expect(nm_eql(n, NMatrix.new([2,2], [0,1,3,4], dtype: :int32))).to be_true
+          expect(nm_eql(n, NMatrix.new([2,2], [0,1,3,4], dtype: :int32))).to be_truthy
         end
 
         it 'should return a 2x2 matrix with refs to self elements' do
@@ -246,7 +246,7 @@ describe "Slice operation" do
 
         it 'should slice again' do
           n = stype_matrix[1..2, 1..2]
-          expect(nm_eql(n[1,0..1], NVector.new(2, [7,8], dtype: :int32).transpose)).to be_true
+          expect(nm_eql(n[1,0..1], NVector.new(2, [7,8], dtype: :int32).transpose)).to be_truthy
         end
 
         it 'should be correct slice for range 0..2 and 0...3' do
@@ -324,7 +324,7 @@ describe "Slice operation" do
             end
 
             it "compares slices to scalars" do
-              (stype_matrix[1, 0..2] > 2).each { |e| expect(e != 0).to be_true }
+              (stype_matrix[1, 0..2] > 2).each { |e| expect(e != 0).to be_truthy }
             end
 
             it "iterates only over elements in the slice" do
@@ -371,20 +371,20 @@ describe "Slice operation" do
 
         [:dense, :list, :yale].each do |cast_type|
           it "should cast a square reference-slice from #{stype.upcase} to #{cast_type.upcase}" do
-            expect(nm_eql(stype_matrix[1..2, 1..2].cast(cast_type), stype_matrix[1..2,1..2])).to be_true
-            expect(nm_eql(stype_matrix[0..1, 1..2].cast(cast_type), stype_matrix[0..1,1..2])).to be_true
-            expect(nm_eql(stype_matrix[1..2, 0..1].cast(cast_type), stype_matrix[1..2,0..1])).to be_true
-            expect(nm_eql(stype_matrix[0..1, 0..1].cast(cast_type), stype_matrix[0..1,0..1])).to be_true
+            expect(nm_eql(stype_matrix[1..2, 1..2].cast(cast_type), stype_matrix[1..2,1..2])).to be_truthy
+            expect(nm_eql(stype_matrix[0..1, 1..2].cast(cast_type), stype_matrix[0..1,1..2])).to be_truthy
+            expect(nm_eql(stype_matrix[1..2, 0..1].cast(cast_type), stype_matrix[1..2,0..1])).to be_truthy
+            expect(nm_eql(stype_matrix[0..1, 0..1].cast(cast_type), stype_matrix[0..1,0..1])).to be_truthy
           end
 
           it "should cast a rectangular reference-slice from #{stype.upcase} to #{cast_type.upcase}" do
             # Non square
-            expect(nm_eql(stype_matrix[0..2, 1..2].cast(cast_type), stype_matrix[0..2,1..2])).to be_true # FIXME: memory problem.
-            expect(nm_eql(stype_matrix[1..2, 0..2].cast(cast_type), stype_matrix[1..2,0..2])).to be_true # this one is fine
+            expect(nm_eql(stype_matrix[0..2, 1..2].cast(cast_type), stype_matrix[0..2,1..2])).to be_truthy # FIXME: memory problem.
+            expect(nm_eql(stype_matrix[1..2, 0..2].cast(cast_type), stype_matrix[1..2,0..2])).to be_truthy # this one is fine
           end
 
           it "should cast a square full-matrix reference-slice from #{stype.upcase} to #{cast_type.upcase}" do
-            expect(nm_eql(stype_matrix[0..2, 0..2].cast(cast_type), stype_matrix)).to be_true
+            expect(nm_eql(stype_matrix[0..2, 0..2].cast(cast_type), stype_matrix)).to be_truthy
           end
         end
       end

--- a/spec/blas_spec.rb
+++ b/spec/blas_spec.rb
@@ -108,7 +108,7 @@ describe NMatrix::BLAS do
     context dtype do
 
       it "exposes cblas rotg" do
-        pending("broken for :object") if dtype == :object
+        skip("broken for :object") if dtype == :object
 
         ab = NMatrix.new([2,1], [6,-8], dtype: dtype)
         c,s = NMatrix::BLAS::rotg(ab)
@@ -118,7 +118,7 @@ describe NMatrix::BLAS do
           expect(ab[1]).to be_within(1e-6).of(-5.quo(3))
           expect(c).to be_within(1e-6).of(-3.quo(5))
         else
-          pending "need correct test cases"
+          skip "need correct test cases"
           expect(ab[0]).to be_within(1e-6).of(10)
           expect(ab[1]).to be_within(1e-6).of(5.quo(3))
           expect(c).to be_within(1e-6).of(3.quo(5))

--- a/spec/io_spec.rb
+++ b/spec/io_spec.rb
@@ -72,7 +72,7 @@ describe NMatrix::IO do
   end
 
   it "loads and saves MatrixMarket .mtx file containing a single large sparse double matrix" do
-    pending "spec disabled because it's so slow"
+    skip "spec disabled because it's so slow"
     n = NMatrix::IO::Market.load("spec/utm5940.mtx")
     NMatrix::IO::Market.save(n, "spec/utm5940.saved.mtx")
     expect(`wc -l spec/utm5940.mtx`.split[0]).to eq(`wc -l spec/utm5940.saved.mtx`.split[0])

--- a/spec/lapack_spec.rb
+++ b/spec/lapack_spec.rb
@@ -103,7 +103,7 @@ describe NMatrix::LAPACK do
           b = NMatrix.new(:dense, 3, [5,3,-1, 0,3,1, 0,0,3], dtype)
           expect(a).to eq(b)
         rescue NotImplementedError => e
-          pending e.to_s
+          skip e.to_s
         end
 
         # then do lower
@@ -136,7 +136,7 @@ describe NMatrix::LAPACK do
           b = NMatrix.new(:dense, 3, [-5,0,-2,-4,1,-1,1.5,0,0.5], dtype)
           expect(a).to eq(b)
         rescue NotImplementedError => e
-          pending e.to_s
+          skip e.to_s
         end
       end
 
@@ -173,9 +173,9 @@ describe NMatrix::LAPACK do
           ldvt= 6
         elsif [:complex64, :complex128].include? dtype
           #http://software.intel.com/sites/products/documentation/doclib/mkl_sa/11/mkl_lapack_examples/cgesvd_ex.c.htm
-          pending "Example may be wrong"
+          skip "Example may be wrong"
         else
-          pending "Not implemented for non-LAPACK dtypes"
+          skip "Not implemented for non-LAPACK dtypes"
           a = NMatrix.new([4,3], dtype: dtype)
         end
         err = case dtype
@@ -192,7 +192,7 @@ describe NMatrix::LAPACK do
           info = NMatrix::LAPACK::lapack_gesdd(:a, a.shape[0], a.shape[1], a, a.shape[0], s, u, ldu, vt, ldvt, 500)
 
         rescue NotImplementedError => e
-          pending e.to_s
+          skip e.to_s
         end
 
         expect(u).to be_within(err).of(left_true)
@@ -236,7 +236,7 @@ describe NMatrix::LAPACK do
           ldvt= 6
         elsif [:complex64, :complex128].include? dtype
           #http://software.intel.com/sites/products/documentation/doclib/mkl_sa/11/mkl_lapack_examples/cgesvd_ex.c.htm
-          pending "Example may be wrong"
+          skip "Example may be wrong"
           a = NMatrix.new([4,3], [[  5.91, -5.69], [  7.09,  2.72], [  7.78, -4.06], [ -0.79, -7.21], [ -3.15, -4.08], [ -1.89,  3.27], [  4.57, -2.07], [ -3.88, -3.30], [ -4.89,  4.20], [  4.10, -6.70], [  3.28, -3.84], [  3.84,  1.19]].map {|e| Complex(*e) } , dtype: dtype)
           s_true = NMatrix.new([3,1], [17.63, 11.61, 6.78], dtype: dtype)
           left_true = NMatrix.new([4,4], [[-0.86, 0.0], [0.4, 0.0], [0.32, 0.0], [-0.35, 0.13], [-0.24, -0.21], [-0.63, 0.6], [0.15, 0.32], [0.61, 0.61], [-0.36, 0.1]].map {|e| Complex(*e)}, dtype: dtype)
@@ -247,7 +247,7 @@ describe NMatrix::LAPACK do
           ldu = 4
           vt  = NMatrix.new([3,3], 0, dtype: dtype)
           ldvt= 3
-        else 
+        else
           a = NMatrix.new([4,3], dtype: dtype)
         end
         err = case dtype
@@ -264,7 +264,7 @@ describe NMatrix::LAPACK do
           info = NMatrix::LAPACK::lapack_gesvd(:a, :a, a.shape[0], a.shape[1], a, a.shape[0], s, u, ldu, vt, ldvt, 500)
 
         rescue NotImplementedError => e
-          pending e.to_s
+          skip e.to_s
         end
 
         expect(u).to be_within(err).of(left_true)
@@ -273,7 +273,7 @@ describe NMatrix::LAPACK do
         expect(s.transpose).to be_within(err).of(s_true.row(0))
 
       end
- 
+
       it "exposes the convenience gesvd method" do
         # http://software.intel.com/sites/products/documentation/doclib/mkl_sa/11/mkl_lapack_examples/dgesvd_ex.c.htm
         if [:float32, :float64].include? dtype
@@ -308,7 +308,7 @@ describe NMatrix::LAPACK do
           ldvt= 6
         elsif [:complex64, :complex128].include? dtype
           #http://software.intel.com/sites/products/documentation/doclib/mkl_sa/11/mkl_lapack_examples/cgesvd_ex.c.htm
-          pending "Example may be wrong"
+          skip "Example may be wrong"
           a = NMatrix.new([4,3], [[  5.91, -5.69], [  7.09,  2.72], [  7.78, -4.06], [ -0.79, -7.21], [ -3.15, -4.08], [ -1.89,  3.27], [  4.57, -2.07], [ -3.88, -3.30], [ -4.89,  4.20], [  4.10, -6.70], [  3.28, -3.84], [  3.84,  1.19]].map {|e| Complex(*e) } , dtype: dtype)
           s_true = NMatrix.new([3,1], [17.63, 11.61, 6.78], dtype: dtype)
           left_true = NMatrix.new([4,4], [[-0.86, 0.0], [0.4, 0.0], [0.32, 0.0], [-0.35, 0.13], [-0.24, -0.21], [-0.63, 0.6], [0.15, 0.32], [0.61, 0.61], [-0.36, 0.1]].map {|e| Complex(*e)}, dtype: dtype)
@@ -319,7 +319,7 @@ describe NMatrix::LAPACK do
           ldu = 4
           vt  = NMatrix.new([3,3], 0, dtype: dtype)
           ldvt= 3
-        else 
+        else
           a = NMatrix.new([4,3], dtype: dtype)
         end
         err = case dtype
@@ -334,7 +334,7 @@ describe NMatrix::LAPACK do
         begin
           u, s, vt = a.gesvd
         rescue NotImplementedError => e
-          pending e.to_s
+          skip e.to_s
         end
         expect(u).to be_within(err).of(left_true)
         #FIXME: Is the next line correct?
@@ -360,7 +360,7 @@ describe NMatrix::LAPACK do
           ldvt= 6
         elsif [:complex64, :complex128].include? dtype
           #http://software.intel.com/sites/products/documentation/doclib/mkl_sa/11/mkl_lapack_examples/cgesvd_ex.c.htm
-          pending "Example may be wrong"
+          skip "Example may be wrong"
           a = NMatrix.new([4,3], [[  5.91, -5.69], [  7.09,  2.72], [  7.78, -4.06], [ -0.79, -7.21], [ -3.15, -4.08], [ -1.89,  3.27], [  4.57, -2.07], [ -3.88, -3.30], [ -4.89,  4.20], [  4.10, -6.70], [  3.28, -3.84], [  3.84,  1.19]].map {|e| Complex(*e) } , dtype: dtype)
           s_true = NMatrix.new([3,1], [17.63, 11.61, 6.78], dtype: dtype)
           left_true = NMatrix.new([4,4], [[-0.86, 0.0], [0.4, 0.0], [0.32, 0.0], [-0.35, 0.13], [-0.24, -0.21], [-0.63, 0.6], [0.15, 0.32], [0.61, 0.61], [-0.36, 0.1]].map {|e| Complex(*e)}, dtype: dtype)
@@ -371,7 +371,7 @@ describe NMatrix::LAPACK do
           ldu = 4
           vt  = NMatrix.new([3,3], 0, dtype: dtype)
           ldvt= 3
-        else 
+        else
           a = NMatrix.new([4,3], dtype: dtype)
         end
         s   = NMatrix.new([5,1], 0, dtype: dtype)
@@ -393,7 +393,7 @@ describe NMatrix::LAPACK do
           u, s, vt = a.gesdd(500)
 
         rescue NotImplementedError => e
-          pending e.to_s
+          skip e.to_s
         end
         expect(u).to be_within(err).of(left_true)
         #FIXME: Is the next line correct?
@@ -403,7 +403,7 @@ describe NMatrix::LAPACK do
 
 
       it "exposes geev" do
-        pending("needs rational implementation") if dtype.to_s =~ /rational/
+        skip("needs rational implementation") if dtype.to_s =~ /rational/
         ary = %w|-1.01 0.86 -4.60 3.31 -4.81
                      3.98 0.53 -7.04 5.29 3.55
                      3.30 8.26 -3.89 8.20 -1.51
@@ -431,7 +431,7 @@ describe NMatrix::LAPACK do
         vr = vr.transpose
         vl = vl.transpose
 
-        pending("Need complex example") if dtype.to_s =~ /complex/
+        skip("Need complex example") if dtype.to_s =~ /complex/
         vl_true = NMatrix.new(:dense, 5, [0.04,  0.29,  0.13,  0.33, -0.04,
                                           0.62,  0.0,  -0.69,  0.0,  -0.56,
                                          -0.04, -0.58,  0.39,  0.07,  0.13,

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -102,14 +102,14 @@ describe "math" do
               [:asin, :acos, :atan, :atanh].each do |atf|
 
                 it "should correctly apply elementwise #{atf}" do
-                  expect(@m.send(atf)).to eq N.new(@size, 
+                  expect(@m.send(atf)).to eq N.new(@size,
                                                @a.map{ |e| Math.send(atf, e) },
                                                dtype: :float64, stype: stype)
                 end
               end
 
               it "should correctly apply elementtwise atan2" do
-                expect(@m.atan2(@m*0+1)).to eq N.new(@size, 
+                expect(@m.atan2(@m*0+1)).to eq N.new(@size,
                   @a.map { |e| Math.send(:atan2, e, 1) }, dtype: :float64, stype: stype)
               end
 
@@ -123,8 +123,8 @@ describe "math" do
             end
           end
         end
-          
-        context "Floor and ceil for #{stype}" do  
+
+        context "Floor and ceil for #{stype}" do
 
           [:floor, :ceil].each do |meth|
             ALL_DTYPES.each do |dtype|
@@ -137,7 +137,7 @@ describe "math" do
 
                 if dtype.to_s.match(/int/) or [:byte, :object].include?(dtype)
                   it "should return #{dtype} for #{dtype}" do
-                    
+
                     expect(@m.send(meth)).to eq N.new(@size, @a.map { |e| e.send(meth) }, dtype: dtype, stype: stype)
 
                     if dtype == :object
@@ -146,14 +146,14 @@ describe "math" do
                       expect(@m.send(meth).integer_dtype?).to eq true
                     end
                   end
-                elsif dtype.to_s.match(/float/) or dtype.to_s.match(/rational/) 
+                elsif dtype.to_s.match(/float/) or dtype.to_s.match(/rational/)
                   it "should return dtype int64 for #{dtype}" do
 
                     expect(@m.send(meth)).to eq N.new(@size, @a.map { |e| e.send(meth) }, dtype: dtype, stype: stype)
-                    
+
                     expect(@m.send(meth).dtype).to eq :int64
                   end
-                elsif dtype.to_s.match(/complex/) 
+                elsif dtype.to_s.match(/complex/)
                   it "should properly calculate #{meth} for #{dtype}" do
 
                     expect(@m.send(meth)).to eq N.new(@size, @a.map { |e| e = Complex(e.real.send(meth), e.imag.send(meth)) }, dtype: dtype, stype: stype)
@@ -172,25 +172,25 @@ describe "math" do
             context dtype do
               before :each do
                 @size = [2,2]
-                @mat  = NMatrix.new @size, [1.33334, 0.9998, 1.9999, -8.9999], 
+                @mat  = NMatrix.new @size, [1.33334, 0.9998, 1.9999, -8.9999],
                   dtype: dtype, stype: stype
                 @ans  = @mat.to_a.flatten
               end
 
               it "rounds #{dtype} for #{stype}" do
-                expect(@mat.round).to eq(N.new(@size, @ans.map { |a| a.round}, 
+                expect(@mat.round).to eq(N.new(@size, @ans.map { |a| a.round},
                   dtype: dtype, stype: stype))
               end unless(/complex/ =~ dtype)
 
               it "rounds complex dtype #{dtype} for #{stype}" do
-                
-                expect(@mat.round).to eq(N.new [2,2], @ans.map {|a| 
+
+                expect(@mat.round).to eq(N.new [2,2], @ans.map {|a|
                   Complex(a.real.round, a.imag.round)},dtype: dtype, stype: stype)
               end if(/complex/ =~ dtype)
             end
           end
         end
-        
+
       end
     end
   end
@@ -218,9 +218,9 @@ describe "math" do
           a.invert!
         rescue NotImplementedError => e
           if dtype.to_s =~ /rational/
-            pending "getri needs rational implementation"
+            skip "getri needs rational implementation"
           else
-            pending e.to_s
+            skip e.to_s
           end
         end
         expect(a.round).to eq(b)
@@ -228,9 +228,9 @@ describe "math" do
 
       unless NMatrix.has_clapack?
         it "should correctly invert a matrix in place" do
-          a = NMatrix.new(:dense, 5, [1, 8,-9, 7, 5, 
-                                      0, 1, 0, 4, 4, 
-                                      0, 0, 1, 2, 5, 
+          a = NMatrix.new(:dense, 5, [1, 8,-9, 7, 5,
+                                      0, 1, 0, 4, 4,
+                                      0, 0, 1, 2, 5,
                                       0, 0, 0, 1,-5,
                                       0, 0, 0, 0, 1 ], dtype)
           b = NMatrix.new(:dense, 5, [1,-8, 9, 7, 17,

--- a/spec/shortcuts_spec.rb
+++ b/spec/shortcuts_spec.rb
@@ -53,7 +53,7 @@ describe NMatrix do
   it "diag() creates a matrix with pre-supplied diagonal" do
     arr = [1,2,3,4]
     m = NMatrix.diag(arr)
-    expect(m.is_a?(NMatrix)).to be_true
+    expect(m.is_a?(NMatrix)).to be_truthy
   end
 
   it "diagonals() contains the seeded values on the diagonal" do
@@ -165,19 +165,19 @@ describe NMatrix do
   it "column() returns a NMatrix" do
     m = NMatrix.random(3)
 
-    expect(m.column(2).is_a?(NMatrix)).to be_true
+    expect(m.column(2).is_a?(NMatrix)).to be_truthy
   end
 
   it "row() returns a NMatrix" do
     m = NMatrix.random(3)
 
-    expect(m.row(2).is_a?(NMatrix)).to be_true
+    expect(m.row(2).is_a?(NMatrix)).to be_truthy
   end
 
   it "diagonals() creates an NMatrix" do
     arr = [1,2,3,4]
     m = NMatrix.diagonals(arr)
-    expect(m.is_a?(NMatrix)).to be_true
+    expect(m.is_a?(NMatrix)).to be_truthy
   end
 
   it "diagonals() contains the seeded values on the diagonal" do


### PR DESCRIPTION
I was using NMatrix recently and found some deprecation warnings when running `rake spec` with RSpec 2.99.2:

```
The semantics of `RSpec::Core::Pending#pending` are changing in
RSpec 3.  In RSpec 2.x, it caused the example to be skipped. [...]

To keep the same skip semantics, change `pending` to `skip`.

`be_false` is deprecated. Use `be_falsey` (for Ruby's conditional semantics) or `be false` (for exact `== false` equality) instead. Called from /Users/carlosagarie/Projects/nmatrix/spec/02_slice_spec.rb:130:in `block (4 levels) in <top (required)>'.

`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /Users/carlosagarie/Projects/nmatrix/spec/02_slice_spec.rb:131:in `block (4 levels) in <top (required)>'.
```

I did the changes specified in these warnings (keeping the current behavior) in this patch.