### PR TITLE
NMatrix.hermitian? Bugfix

### DIFF
--- a/ext/nmatrix/storage/dense/dense.cpp
+++ b/ext/nmatrix/storage/dense/dense.cpp
@@ -1030,7 +1030,7 @@ bool is_hermitian(const DENSE_STORAGE* mat, int lda) {
 
 	for (i = mat->shape[0]; i-- > 0;) {
 		for (j = i + 1; j < mat->shape[1]; ++j) {
-			complex_conj		= els[j*lda + 1];
+			complex_conj		= els[j*lda + i];
 			complex_conj.i	= -complex_conj.i;
 
 			if (els[i*lda+j] != complex_conj) {

--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -475,27 +475,6 @@ class NMatrix
 
   #
   # call-seq:
-  #     hermitian? -> Boolean
-  #
-  # A hermitian matrix is a complex square matrix that is equal to its
-  # conjugate transpose. (http://en.wikipedia.org/wiki/Hermitian_matrix)
-  #
-  # * *Returns* :
-  #   - True if +self+ is a hermitian matrix, nil otherwise.
-  #
-  def hermitian?
-    return false if self.dim != 2 or self.shape[0] != self.shape[1]
-
-    if [:complex64, :complex128].include?(self.dtype)
-      # TODO: Write much faster Hermitian test in C
-      self.eql?(self.conjugate_transpose)
-    else
-      symmetric?
-    end
-  end
-
-  #
-  # call-seq:
   #     trace -> Numeric
   #
   # Calculates the trace of an nxn matrix.

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -422,6 +422,18 @@ describe "math" do
         expect(n.symmetric?).to be_truthy
       end
     end
+
+    context "#hermitian? for #{dtype}" do
+      it "should return true for complex hermitian or non-complex symmetric matrix" do 
+        n = NMatrix.new([3,3], [1.00000, 0.56695, 0.53374,
+                                0.56695, 1.00000, 0.77813,
+                                0.53374, 0.77813, 1.00000], dtype: dtype) unless dtype =~ /complex/
+        n = NMatrix.new([3,3], [1.1, Complex(1.2,1.3), Complex(1.4,1.5),
+                                Complex(1.2,-1.3), 1.9, Complex(1.8,1.7),
+                                Complex(1.4,-1.5), Complex(1.8,-1.7), 1.3], dtype: dtype) if dtype =~ /complex/
+        expect(n.hermitian?).to be_truthy
+      end
+    end
   end
 
   context "#solve" do


### PR DESCRIPTION
I ran into problems with NMatrix.hermitian?, and fixed it.

More precisely:
- I removed the ruby implementation of .hermitian? from math.rb, because a cpp implementation was already available via ruby_nmatrix.c and dense.cpp
- I corrected a typo in is_hermitian in dense.cpp
- I made a test for .hermitian?

By the way, the ruby implementation (which was redundant) from math.rb seemed flawed to me anyway because the line self.eql?(self.conjugate_transpose) compares if self and self.conjugate_transpose point to the same object, and not whether the matrices have the same values.. or am I mistaken here? (sorry for the dumb question but ruby is very new to me)