### PR TITLE
Fixed issue #329: rake compile doesn't rebuild if only .h files modified

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ Rake::ExtensionTask.new do |ext|
     ext.name = 'nmatrix'
     ext.ext_dir = 'ext/nmatrix'
     ext.lib_dir = 'lib/'
-    ext.source_pattern = "**/*.{c,cpp, h}"
+    ext.source_pattern = "**/*.{c,cpp,h}"
 end
 
 gemspec = eval(IO.read("nmatrix.gemspec"))


### PR DESCRIPTION
Hi I had exactly the same problem while working with C++ code in matrix as described in #329 The problem was trivial: there was a space in ext.source_pattern before 'h'. This pattern is used to monitor files for which rake-compiles should trigger C++. Now build works as expected. HTH. 

BTW. Generated Makefile by mkmf is perfectly fine, with dependencies between  *.o and *.h. 
 