### PR TITLE
make #permute_columns more intuitive to use

### DIFF
--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -350,11 +350,11 @@ class NMatrix
   #
   # If +:convention+ is +:lapack+, then +ary+ represents a sequence of pair-wise permutations which are 
   # performed successively. That is, the i'th entry of +ary+ is the index of the column to swap 
-  # the i'th column with, having already applied all earlier swaps. This is the default.
+  # the i'th column with, having already applied all earlier swaps. 
   #
   # If +:convention+ is +:intuitive+, then +ary+ represents the order of columns after the permutation. 
   # That is, the i'th entry of +ary+ is the index of the column that will be in position i after the 
-  # reordering (Matlab-like behaviour). 
+  # reordering (Matlab-like behaviour). This is the default.
   #
   # Not yet implemented for yale or list. 
   #
@@ -364,11 +364,11 @@ class NMatrix
   # 
   # == Options
   # 
-  # * +:covention+ - Possible values are +:lapack+ and +:intuitive+. Default is +:lapack+. See above for details.
+  # * +:covention+ - Possible values are +:lapack+ and +:intuitive+. Default is +:intuitive+. See above for details.
   #
   def laswp!(ary, opts={})
     raise(StorageTypeError, "ATLAS functions only work on dense matrices") unless self.dense?
-    opts = { convention: :lapack }.merge(opts)
+    opts = { convention: :intuitive }.merge(opts)
     
     if opts[:convention] == :intuitive
       if ary.length != ary.uniq.length

--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -341,24 +341,80 @@ class NMatrix
   def gesdd(workspace_size=nil)
     self.clone.gesdd!(workspace_size)
   end
+
   #
   # call-seq:
   #     laswp!(ary) -> NMatrix
   #
-  # In-place permute the columns of a dense matrix using LASWP according to the order given in an Array +ary+.
-  # Not yet implemented for yale or list.
-  def laswp!(ary)
-    NMatrix::LAPACK::laswp(self, ary)
+  # In-place permute the columns of a dense matrix using LASWP according to the order given as an array +ary+.
+  #
+  # If +:convention+ is +:lapack+, then +ary+ represents a sequence of pair-wise permutations which are 
+  # performed successively. That is, the i'th entry of +ary+ is the index of the column to swap 
+  # the i'th column with, having already applied all earlier swaps. This is the default.
+  #
+  # If +:convention+ is +:intuitive+, then +ary+ represents the order of columns after the permutation. 
+  # That is, the i'th entry of +ary+ is the index of the column that will be in position i after the 
+  # reordering (Matlab-like behaviour). 
+  #
+  # Not yet implemented for yale or list. 
+  #
+  # == Arguments
+  #
+  # * +ary+ - An Array specifying the order of the columns. See above for details.
+  # 
+  # == Options
+  # 
+  # * +:covention+ - Possible values are +:lapack+ and +:intuitive+. Default is +:lapack+. See above for details.
+  #
+  def laswp!(ary, opts={})
+    raise(StorageTypeError, "ATLAS functions only work on dense matrices") unless self.dense?
+    opts = { convention: :lapack }.merge(opts)
+    
+    if opts[:convention] == :intuitive
+      if ary.length != ary.uniq.length
+        raise(ArgumentError, "No duplicated entries in the order array are allowed under convention :intuitive")
+      end
+      n = self.shape[1]
+      p = []
+      order = (0...n).to_a
+      0.upto(n-2) do |i|
+        p[i] = order.index(ary[i])
+        order[i], order[p[i]] = order[p[i]], order[i]
+      end
+      p[n-1] = n-1
+    else
+      p = ary
+    end
+
+    NMatrix::LAPACK::laswp(self, p)
   end
 
   #
   # call-seq:
   #     laswp(ary) -> NMatrix
   #
-  # Permute the columns of a dense matrix using LASWP according to the order given in an Array +ary+.
-  # Not yet implemented for yale or list.
-  def laswp(ary)
-    self.clone.laswp!(ary)
+  # Permute the columns of a dense matrix using LASWP according to the order given in an array +ary+.
+  #
+  # If +:convention+ is +:lapack+, then +ary+ represents a sequence of pair-wise permutations which are 
+  # performed successively. That is, the i'th entry of +ary+ is the index of the column to swap 
+  # the i'th column with, having already applied all earlier swaps. This is the default.
+  #
+  # If +:convention+ is +:intuitive+, then +ary+ represents the order of columns after the permutation. 
+  # That is, the i'th entry of +ary+ is the index of the column that will be in position i after the 
+  # reordering (Matlab-like behaviour). 
+  #
+  # Not yet implemented for yale or list. 
+  #
+  # == Arguments
+  #
+  # * +ary+ - An Array specifying the order of the columns. See above for details.
+  # 
+  # == Options
+  # 
+  # * +:covention+ - Possible values are +:lapack+ and +:intuitive+. Default is +:lapack+. See above for details.
+  #
+  def laswp(ary, opts={})
+    self.clone.laswp!(ary, opts)
   end
 
   #
@@ -434,7 +490,7 @@ class NMatrix
   # == Options
   # 
   # * +:for_sample_data+ - Default true. If set to false will consider the denominator for
-  #   population data (i.e. N-1).
+  #   population data (i.e. N, as opposed to N-1 for sample data).
   # 
   # == References
   # 
@@ -459,7 +515,7 @@ class NMatrix
   end
 
   # Raise a square matrix to a power. Be careful of numeric overflows!
-  # In case *n* is 0, a matrix of ones of the same dimension is returned. In case
+  # In case *n* is 0, an identity matrix of the same dimension is returned. In case
   # of negative *n*, the matrix is inverted and the absolute value of *n* taken 
   # for computing the power.
   # 

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -434,6 +434,50 @@ describe "math" do
         expect(n.hermitian?).to be_truthy
       end
     end
+
+    context "#permute_columns for #{dtype}" do
+      it "check that #permute_columns works correctly by considering every premutation of a 3x3 matrix" do
+        n = NMatrix.new([3,3], [1,0,0,
+                                0,2,0,
+                                0,0,3], dtype: dtype)
+        expect(n.permute_columns([0,1,2], {convention: :intuitive})).to eq(NMatrix.new([3,3], [1,0,0,
+                                                                                              0,2,0,
+                                                                                              0,0,3], dtype: dtype))
+        expect(n.permute_columns([0,2,1], {convention: :intuitive})).to eq(NMatrix.new([3,3], [1,0,0,
+                                                                                              0,0,2,
+                                                                                              0,3,0], dtype: dtype))
+        expect(n.permute_columns([1,0,2], {convention: :intuitive})).to eq(NMatrix.new([3,3], [0,1,0,
+                                                                                              2,0,0,
+                                                                                              0,0,3], dtype: dtype))
+        expect(n.permute_columns([1,2,0], {convention: :intuitive})).to eq(NMatrix.new([3,3], [0,0,1,
+                                                                                              2,0,0,
+                                                                                              0,3,0], dtype: dtype))
+        expect(n.permute_columns([2,0,1], {convention: :intuitive})).to eq(NMatrix.new([3,3], [0,1,0,
+                                                                                              0,0,2,
+                                                                                              3,0,0], dtype: dtype))
+        expect(n.permute_columns([2,1,0], {convention: :intuitive})).to eq(NMatrix.new([3,3], [0,0,1,
+                                                                                              0,2,0,
+                                                                                              3,0,0], dtype: dtype))
+        expect(n.permute_columns([0,1,2], {convention: :lapack})).to eq(NMatrix.new([3,3], [1,0,0,
+                                                                                           0,2,0,
+                                                                                           0,0,3], dtype: dtype))
+        expect(n.permute_columns([0,2,2], {convention: :lapack})).to eq(NMatrix.new([3,3], [1,0,0,
+                                                                                           0,0,2,
+                                                                                           0,3,0], dtype: dtype))
+        expect(n.permute_columns([1,1,2], {convention: :lapack})).to eq(NMatrix.new([3,3], [0,1,0,
+                                                                                           2,0,0,
+                                                                                           0,0,3], dtype: dtype))
+        expect(n.permute_columns([1,2,2], {convention: :lapack})).to eq(NMatrix.new([3,3], [0,0,1,
+                                                                                           2,0,0,
+                                                                                           0,3,0], dtype: dtype))
+        expect(n.permute_columns([2,2,2], {convention: :lapack})).to eq(NMatrix.new([3,3], [0,1,0,
+                                                                                           0,0,2,
+                                                                                           3,0,0], dtype: dtype))
+        expect(n.permute_columns([2,1,2], {convention: :lapack})).to eq(NMatrix.new([3,3], [0,0,1,
+                                                                                           0,2,0,
+                                                                                           3,0,0], dtype: dtype))
+      end
+    end
   end
 
   context "#solve" do

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -477,6 +477,27 @@ describe "math" do
                                                                                            0,2,0,
                                                                                            3,0,0], dtype: dtype))
       end
+      it "additional tests for  #permute_columns with convention :intuitive" do
+        m = NMatrix.new([1,4], [0,1,2,3], dtype: dtype)
+        perm = [1,0,3,2]
+        expect(m.permute_columns(perm, {convention: :intuitive})).to eq(NMatrix.new([1,4], perm, dtype: dtype))
+
+        m = NMatrix.new([1,5], [0,1,2,3,4], dtype: dtype)
+        perm = [1,0,4,3,2]
+        expect(m.permute_columns(perm, {convention: :intuitive})).to eq(NMatrix.new([1,5], perm, dtype: dtype))
+
+        m = NMatrix.new([1,6], [0,1,2,3,4,5], dtype: dtype)
+        perm = [2,4,1,0,5,3]
+        expect(m.permute_columns(perm, {convention: :intuitive})).to eq(NMatrix.new([1,6], perm, dtype: dtype))
+
+        m = NMatrix.new([1,7], [0,1,2,3,4,5,6], dtype: dtype)
+        perm = [1,3,5,6,0,2,4]
+        expect(m.permute_columns(perm, {convention: :intuitive})).to eq(NMatrix.new([1,7], perm, dtype: dtype))
+
+        m = NMatrix.new([1,8], [0,1,2,3,4,5,6,7], dtype: dtype)
+        perm = [6,7,5,4,1,3,0,2]
+        expect(m.permute_columns(perm, {convention: :intuitive})).to eq(NMatrix.new([1,8], perm, dtype: dtype))
+      end
     end
   end
 


### PR DESCRIPTION
While discussing my pull request https://github.com/SciRuby/nmatrix/pull/336 with @cjfuller, I got surprised by the behaviour of `#permute_columns`, which is very inconvenient for everybody who is used to Matlab or R (and I think that this surprising behaviour is also not explicitly documented).

Assume we have a matrix consisting of five columns *a0, a1, a2, a3, a4*, and assume that we want to reorder them as *a2, a0, a3, a4, a1*.
In *Matlab* or *R* we could easily supply the new column order *(3, 1, 4, 5, 2)* as the column index in order to get the desired column permutation.
With the current version of *NMatrix* however, we have to supply the array `[2, 2, 3, 4, 4]` as input to the method `#permute_columns` (additionally, the permutation array is not unique), because the permutation array represents a sequence of pair-wise permutations which are performed successively.

A lot of times in scientific computation, one needs to reorder the columns of a matrix in a specific order. It seems very inconvenient having to sit down with a pen and a piece of paper in order to figure out the sequence of successive pair-wise permutations. 

As suggested by @cjfuller I added an option `:convention` to the method which can either be set to `:lapack` or `:intuitive` (`:lapack` is the default for back compatibility). 

That is, in the example from above we would use the permutation vector `[2, 0, 3, 4, 1]` and set `:convention` to `:intuitive` in order to get the desired reordering *a2, a0, a3, a4, a1*.

I explain my implementation of the `:intuitive` option in more detail in a blog post http://agisga.github.io/Permute-Columns-Of-An-NMatrix/
