### PR TITLE
Patches for MacOSX

### DIFF
--- a/ext/nmatrix/data/data.cpp
+++ b/ext/nmatrix/data/data.cpp
@@ -219,6 +219,36 @@ void rubyval_to_cval(VALUE val, nm::dtype_t dtype, void* loc) {
 	}
 }
 
+
+
+/*
+ * Allocate and return a piece of data of the correct dtype, converted from a
+ * given RubyObject.
+ */
+void* rubyobj_to_cval(VALUE val, nm::dtype_t dtype) {
+  size_t size =  DTYPE_SIZES[dtype];
+  NM_CONSERVATIVE(nm_register_value(&val));
+  void* ret_val = NM_ALLOC_N(char, size);
+
+  rubyval_to_cval(val, dtype, ret_val);
+  NM_CONSERVATIVE(nm_unregister_value(&val));
+  return ret_val;
+}
+
+
+void nm_init_data() {
+  volatile VALUE t = INT2FIX(1);
+  volatile nm::RubyObject obj(t);
+  volatile nm::Rational32 x(const_cast<nm::RubyObject&>(obj));
+  volatile nm::Rational64 y(const_cast<nm::RubyObject&>(obj));
+  volatile nm::Rational128 z(const_cast<nm::RubyObject&>(obj));
+  volatile nm::Complex64 a(const_cast<nm::RubyObject&>(obj));
+  volatile nm::Complex128 b(const_cast<nm::RubyObject&>(obj));
+}
+
+
+} // end of extern "C" block
+
 /*
  * Create a RubyObject from a regular C value (given a dtype). Does not return a VALUE! To get a VALUE, you need to
  * look at the rval property of what this function returns.
@@ -274,33 +304,3 @@ nm::RubyObject rubyobj_from_cval(void* val, nm::dtype_t dtype) {
 	}
 	return Qnil;
 }
-
-
-
-/*
- * Allocate and return a piece of data of the correct dtype, converted from a
- * given RubyObject.
- */
-void* rubyobj_to_cval(VALUE val, nm::dtype_t dtype) {
-  size_t size =  DTYPE_SIZES[dtype];
-  NM_CONSERVATIVE(nm_register_value(&val));
-  void* ret_val = NM_ALLOC_N(char, size);
-
-  rubyval_to_cval(val, dtype, ret_val);
-  NM_CONSERVATIVE(nm_unregister_value(&val));
-  return ret_val;
-}
-
-
-void nm_init_data() {
-  volatile VALUE t = INT2FIX(1);
-  volatile nm::RubyObject obj(t);
-  volatile nm::Rational32 x(const_cast<nm::RubyObject&>(obj));
-  volatile nm::Rational64 y(const_cast<nm::RubyObject&>(obj));
-  volatile nm::Rational128 z(const_cast<nm::RubyObject&>(obj));
-  volatile nm::Complex64 a(const_cast<nm::RubyObject&>(obj));
-  volatile nm::Complex128 b(const_cast<nm::RubyObject&>(obj));
-}
-
-
-} // end of extern "C" block

--- a/ext/nmatrix/data/data.h
+++ b/ext/nmatrix/data/data.h
@@ -766,10 +766,11 @@ extern const nm::dtype_t Upcast[nm::NUM_DTYPES][nm::NUM_DTYPES];
 
 void*	    			rubyobj_to_cval(VALUE val, nm::dtype_t dtype);
 void  		  		rubyval_to_cval(VALUE val, nm::dtype_t dtype, void* loc);
-nm::RubyObject	rubyobj_from_cval(void* val, nm::dtype_t dtype);
 
 void nm_init_data();
 
 } // end of extern "C" block
+
+nm::RubyObject	rubyobj_from_cval(void* val, nm::dtype_t dtype);
 
 #endif // DATA_H

--- a/ext/nmatrix/data/ruby_object.h
+++ b/ext/nmatrix/data/ruby_object.h
@@ -139,6 +139,7 @@ class RubyObject {
    */
 	inline RubyObject inverse() const {
 	  rb_raise(rb_eNotImpError, "RubyObject#inverse needs to be implemented");
+	  return Qnil; //not reached
 	}
 
 	/*
@@ -312,6 +313,7 @@ class RubyObject {
 			
 		} else {
 			rb_raise(rb_eTypeError, "Invalid conversion to Complex type.");
+			return nm::RUBYOBJ; //not reached
 		}
 	}
 	
@@ -328,6 +330,7 @@ class RubyObject {
 			
 		} else {
 			rb_raise(rb_eTypeError, "Invalid conversion to Rational type.");
+			return nm::RUBYOBJ; //not reached
 		}
 	}
 

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -195,17 +195,14 @@ end
 
 # Order matters here: ATLAS has to go after LAPACK: http://mail.scipy.org/pipermail/scipy-user/2007-January/010717.html
 #$libs += " -llapack -lcblas -latlas "
-unless have_library("atlas")
-  dir_config("atlas", idefaults[:atlas], ldefaults[:atlas])
-end
+dir_config("atlas")
+find_library("atlas", nil, *ldefaults[:atlas])
 
-unless have_library("cblas")
-  dir_config("cblas", idefaults[:cblas], ldefaults[:cblas])
-end
+dir_config("cblas")
+find_library("cblas", nil, *ldefaults[:cblas])
 
-unless have_library("lapack")
-  dir_config("lapack", idefaults[:lapack], ldefaults[:lapack])
-end
+dir_config("lapack")
+find_library("lapack", nil, *ldefaults[:lapack])
 
 # If BLAS and LAPACK headers are in an atlas directory, prefer those. Otherwise,
 # we try our luck with the default location.

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -210,8 +210,17 @@ end
 if have_header("atlas/cblas.h")
   have_header("atlas/clapack.h")
 else
-  have_header("cblas.h")
-  have_header("clapack.h")
+  find_header("cblas.h", *idefaults[:cblas]) and have_header("cblas.h")
+  if find_header("clapack.h", *idefaults[:cblas])
+    # set HAVE_CLAPACK_H only if clapack.h provides clapack_dgetrf
+    try_compile(<<EOS) and have_header("clapack.h", "-Werror=implicit-function-declaration")
+#include <cblas.h>
+#include <clapack.h>
+int test(void){
+  return clapack_dgetrf(CblasRowMajor, CblasNoTrans, 0, 0, (double*)NULL, 0, (int*)NULL);
+}
+EOS
+  end
 end
 
 

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -172,7 +172,14 @@ end
 # (substituting in the path of your cblas.h and clapack.h for the path I used). -- JW 8/27/12
 
 idefaults = {lapack: ["/usr/include/atlas"],
-             cblas: ["/usr/local/atlas/include", "/usr/include/atlas"],
+             cblas: ["/usr/local/atlas/include", "/usr/include/atlas",
+                     "/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Versions/Current/Headers",
+                     "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/include",
+                     "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Versions/Current/Headers/",
+                     "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/usr/include",
+                     "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Versions/Current/Headers/",
+                     "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/usr/include",
+                     "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Versions/Current/Headers/"],
              atlas: ["/usr/local/atlas/include", "/usr/include/atlas"]}
 
 # For some reason, if we try to look for /usr/lib64/atlas on a Mac OS X Mavericks system, and the directory does not

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -193,16 +193,18 @@ if have_library("clapack") # Usually only applies for Mac OS X
   $libs += " -lclapack "
 end
 
-unless have_library("lapack")
-  dir_config("lapack", idefaults[:lapack], ldefaults[:lapack])
+# Order matters here: ATLAS has to go after LAPACK: http://mail.scipy.org/pipermail/scipy-user/2007-January/010717.html
+#$libs += " -llapack -lcblas -latlas "
+unless have_library("atlas")
+  dir_config("atlas", idefaults[:atlas], ldefaults[:atlas])
 end
 
 unless have_library("cblas")
   dir_config("cblas", idefaults[:cblas], ldefaults[:cblas])
 end
 
-unless have_library("atlas")
-  dir_config("atlas", idefaults[:atlas], ldefaults[:atlas])
+unless have_library("lapack")
+  dir_config("lapack", idefaults[:lapack], ldefaults[:lapack])
 end
 
 # If BLAS and LAPACK headers are in an atlas directory, prefer those. Otherwise,
@@ -239,8 +241,6 @@ have_func("cblas_dgemm", "cblas.h")
 #find_library("lapack", "clapack_dgetrf")
 #find_library("cblas", "cblas_dgemm")
 #find_library("atlas", "ATL_dgemmNN")
-# Order matters here: ATLAS has to go after LAPACK: http://mail.scipy.org/pipermail/scipy-user/2007-January/010717.html
-$libs += " -llapack -lcblas -latlas "
 #$libs += " -lprofiler "
 
 

--- a/ext/nmatrix/nmatrix.cpp
+++ b/ext/nmatrix/nmatrix.cpp
@@ -110,6 +110,7 @@ namespace nm {
   template <typename DType>
   size_t write_padded_dense_elements_herm(std::ofstream& f, DENSE_STORAGE* storage, symm_t symm) {
     rb_raise(rb_eArgError, "cannot write a non-complex matrix as hermitian");
+    return 0; // not reached
   }
 
   template <>

--- a/ext/nmatrix/ruby_nmatrix.c
+++ b/ext/nmatrix/ruby_nmatrix.c
@@ -1118,11 +1118,14 @@ static VALUE nm_reshape_bang(VALUE self, VALUE arg){
       }
       return self;
      }
-     else
+     else {
        rb_raise(rb_eArgError, "reshape cannot resize; size of new and old matrices must match");
+       return Qnil; // not reached
+     }
   }
   else {
     rb_raise(rb_eNotImpError, "reshape in place only for dense stype");
+    return Qnil; // not reached
   }
 }
 
@@ -2666,6 +2669,7 @@ nm::dtype_t nm_dtype_guess(VALUE v) {
   default:
     RB_P(v);
     rb_raise(rb_eArgError, "Unable to guess a data type from provided parameters; data type must be specified manually.");
+    return nm::RUBYOBJ; // not reached
   }
 }
 
@@ -2803,7 +2807,7 @@ static nm::dtype_t interpret_dtype(int argc, VALUE* argv, nm::stype_t stype) {
 
   } else if (stype == nm::YALE_STORE) {
   	rb_raise(rb_eArgError, "Yale storage class requires a dtype.");
-
+  	return nm::RUBYOBJ; // not reached
   } else {
   	return nm_dtype_guess(argv[0]);
   }
@@ -2881,6 +2885,7 @@ static nm::stype_t interpret_stype(VALUE arg) {
 
   } else {
   	rb_raise(rb_eArgError, "Expected storage type");
+  	return nm::DENSE_STORE; // not reached
   }
 }
 

--- a/ext/nmatrix/util/io.cpp
+++ b/ext/nmatrix/util/io.cpp
@@ -110,6 +110,7 @@ nm::dtype_t nm_dtype_from_rbstring(VALUE str) {
   }
 
   rb_raise(rb_eArgError, "invalid data type string (%s) specified", RSTRING_PTR(str));
+  return nm::RUBYOBJ; //not reached
 }
 
 
@@ -127,6 +128,7 @@ nm::dtype_t nm_dtype_from_rbsymbol(VALUE sym) {
 
   VALUE str = rb_any_to_s(sym);
   rb_raise(rb_eArgError, "invalid data type symbol (:%s) specified", RSTRING_PTR(str));
+  return nm::RUBYOBJ; //not reached
 }
 
 
@@ -174,6 +176,7 @@ static nm::io::matlab_dtype_t matlab_dtype_from_rbsymbol(VALUE sym) {
   }
 
   rb_raise(rb_eArgError, "Invalid matlab type specified.");
+  return nm::io::matlab_dtype_t::miINT8; //not reached
 }
 
 


### PR DESCRIPTION
These patches are for easy builds on MacOSX.
Unfortunately, I was not authorized to install old Xcode onto the MacOSX box on which I tested the patches, so they are not tested with Xcode 5.1.1 yet.
Although, they looks good except for the lack of clapack_xxxxx functions.