### PR TITLE
Makes it easier for people to install NMatrix if they don't have a functional CBLAS installation

### DIFF
--- a/ext/nmatrix/math.cpp
+++ b/ext/nmatrix/math.cpp
@@ -117,7 +117,7 @@
 #include <limits>
 #include <cmath>
 
-#ifndef HAVE_CBLAS_H
+#if !(defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
 #include "math/cblas_enums.h"
 #endif
 
@@ -1126,7 +1126,7 @@ static VALUE nm_cblas_trsm(VALUE self,
       NULL, NULL, NULL, NULL, NULL, // integers not allowed due to division
       nm::math::cblas_trsm<float>,
       nm::math::cblas_trsm<double>,
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
       cblas_ctrsm, cblas_ztrsm, // call directly, same function signature!
 #else
       nm::math::cblas_trsm<nm::Complex64>,
@@ -1170,7 +1170,7 @@ static VALUE nm_cblas_trmm(VALUE self,
       NULL, NULL, NULL, NULL, NULL, // integers not allowed due to division
       nm::math::cblas_trmm<float>,
       nm::math::cblas_trmm<double>,
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
       cblas_ctrmm, cblas_ztrmm // call directly, same function signature!
 #else
       nm::math::cblas_trmm<nm::Complex64>,
@@ -1214,7 +1214,7 @@ static VALUE nm_cblas_syrk(VALUE self,
       NULL, NULL, NULL, NULL, NULL, // integers not allowed due to division
       nm::math::cblas_syrk<float>,
       nm::math::cblas_syrk<double>,
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
       cblas_csyrk, cblas_zsyrk// call directly, same function signature!
 #else
       nm::math::cblas_syrk<nm::Complex64>,
@@ -1257,13 +1257,13 @@ static VALUE nm_cblas_herk(VALUE self,
   nm::dtype_t dtype = NM_DTYPE(a);
 
   if (dtype == nm::COMPLEX64) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
     cblas_cherk(blas_order_sym(order), blas_uplo_sym(uplo), blas_transpose_sym(trans), FIX2INT(n), FIX2INT(k), NUM2DBL(alpha), NM_STORAGE_DENSE(a)->elements, FIX2INT(lda), NUM2DBL(beta), NM_STORAGE_DENSE(c)->elements, FIX2INT(ldc));
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
 #endif
   } else if (dtype == nm::COMPLEX128) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
     cblas_zherk(blas_order_sym(order), blas_uplo_sym(uplo), blas_transpose_sym(trans), FIX2INT(n), FIX2INT(k), NUM2DBL(alpha), NM_STORAGE_DENSE(a)->elements, FIX2INT(lda), NUM2DBL(beta), NM_STORAGE_DENSE(c)->elements, FIX2INT(ldc));
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");

--- a/ext/nmatrix/math.cpp
+++ b/ext/nmatrix/math.cpp
@@ -117,6 +117,10 @@
 #include <limits>
 #include <cmath>
 
+#ifndef HAVE_CBLAS_H
+#include "math/cblas_enums.h"
+#endif
+
 #include "math/inc.h"
 #include "data/data.h"
 #include "math/gesdd.h"
@@ -1122,7 +1126,12 @@ static VALUE nm_cblas_trsm(VALUE self,
       NULL, NULL, NULL, NULL, NULL, // integers not allowed due to division
       nm::math::cblas_trsm<float>,
       nm::math::cblas_trsm<double>,
+#ifdef HAVE_CBLAS_H
       cblas_ctrsm, cblas_ztrsm, // call directly, same function signature!
+#else
+      nm::math::cblas_trsm<nm::Complex64>,
+      nm::math::cblas_trsm<nm::Complex128>,
+#endif
       nm::math::cblas_trsm<nm::Rational32>,
       nm::math::cblas_trsm<nm::Rational64>,
       nm::math::cblas_trsm<nm::Rational128>,
@@ -1161,7 +1170,12 @@ static VALUE nm_cblas_trmm(VALUE self,
       NULL, NULL, NULL, NULL, NULL, // integers not allowed due to division
       nm::math::cblas_trmm<float>,
       nm::math::cblas_trmm<double>,
+#ifdef HAVE_CBLAS_H
       cblas_ctrmm, cblas_ztrmm // call directly, same function signature!
+#else
+      nm::math::cblas_trmm<nm::Complex64>,
+      nm::math::cblas_trmm<nm::Complex128>
+#endif
       /*
       nm::math::cblas_trmm<nm::Rational32>,
       nm::math::cblas_trmm<nm::Rational64>,
@@ -1200,7 +1214,12 @@ static VALUE nm_cblas_syrk(VALUE self,
       NULL, NULL, NULL, NULL, NULL, // integers not allowed due to division
       nm::math::cblas_syrk<float>,
       nm::math::cblas_syrk<double>,
+#ifdef HAVE_CBLAS_H
       cblas_csyrk, cblas_zsyrk// call directly, same function signature!
+#else
+      nm::math::cblas_syrk<nm::Complex64>,
+      nm::math::cblas_syrk<nm::Complex128>
+#endif
       /*nm::math::cblas_trsm<nm::Rational32>,
       nm::math::cblas_trsm<nm::Rational64>,
       nm::math::cblas_trsm<nm::Rational128>,
@@ -1238,9 +1257,17 @@ static VALUE nm_cblas_herk(VALUE self,
   nm::dtype_t dtype = NM_DTYPE(a);
 
   if (dtype == nm::COMPLEX64) {
+#ifdef HAVE_CBLAS_H
     cblas_cherk(blas_order_sym(order), blas_uplo_sym(uplo), blas_transpose_sym(trans), FIX2INT(n), FIX2INT(k), NUM2DBL(alpha), NM_STORAGE_DENSE(a)->elements, FIX2INT(lda), NUM2DBL(beta), NM_STORAGE_DENSE(c)->elements, FIX2INT(ldc));
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
   } else if (dtype == nm::COMPLEX128) {
+#ifdef HAVE_CBLAS_H
     cblas_zherk(blas_order_sym(order), blas_uplo_sym(uplo), blas_transpose_sym(trans), FIX2INT(n), FIX2INT(k), NUM2DBL(alpha), NM_STORAGE_DENSE(a)->elements, FIX2INT(lda), NUM2DBL(beta), NM_STORAGE_DENSE(c)->elements, FIX2INT(ldc));
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
   } else
     rb_raise(rb_eNotImpError, "this matrix operation undefined for non-complex dtypes");
   return Qtrue;

--- a/ext/nmatrix/math/cblas_enums.h
+++ b/ext/nmatrix/math/cblas_enums.h
@@ -1,0 +1,37 @@
+/////////////////////////////////////////////////////////////////////
+// = NMatrix
+//
+// A linear algebra library for scientific computation in Ruby.
+// NMatrix is part of SciRuby.
+//
+// NMatrix was originally inspired by and derived from NArray, by
+// Masahiro Tanaka: http://narray.rubyforge.org
+//
+// == Copyright Information
+//
+// SciRuby is Copyright (c) 2010 - 2015, Ruby Science Foundation
+// NMatrix is Copyright (c) 2012 - 2015, John Woods and the Ruby Science Foundation
+//
+// Please see LICENSE.txt for additional copyright notices.
+//
+// == Contributing
+//
+// By contributing source code to SciRuby, you agree to be bound by
+// our Contributor Agreement:
+//
+// * https://github.com/SciRuby/sciruby/wiki/Contributor-Agreement
+//
+// == cblas_enums.h
+//
+// CBLAS definitions for when CBLAS is not available.
+//
+
+#ifndef CBLAS_ENUM_DEFINED_H
+#define CBLAS_ENUM_DEFINED_H
+enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102 };
+enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113,
+  AtlasConj=114};
+enum CBLAS_UPLO  {CblasUpper=121, CblasLower=122};
+enum CBLAS_DIAG  {CblasNonUnit=131, CblasUnit=132};
+enum CBLAS_SIDE  {CblasLeft=141, CblasRight=142};
+#endif

--- a/ext/nmatrix/math/gemm.h
+++ b/ext/nmatrix/math/gemm.h
@@ -30,7 +30,7 @@
 #ifndef GEMM_H
 # define GEMM_H
 
-#ifndef HAVE_CBLAS_H
+#if !(defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
 #include "cblas_enums.h"
 #endif
 
@@ -246,7 +246,7 @@ inline void gemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA
 }
 
 
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
 template <>
 inline void gemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB, const int M, const int N, const int K,
           const float* alpha, const float* A, const int lda, const float* B, const int ldb, const float* beta, float* C, const int ldc) {

--- a/ext/nmatrix/math/gemm.h
+++ b/ext/nmatrix/math/gemm.h
@@ -30,6 +30,10 @@
 #ifndef GEMM_H
 # define GEMM_H
 
+#ifndef HAVE_CBLAS_H
+#include "cblas_enums.h"
+#endif
+
 extern "C" { // These need to be in an extern "C" block or you'll get all kinds of undefined symbol errors.
 #if defined HAVE_CBLAS_H
   #include <cblas.h>
@@ -242,6 +246,7 @@ inline void gemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA
 }
 
 
+#ifdef HAVE_CBLAS_H
 template <>
 inline void gemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA, const enum CBLAS_TRANSPOSE TransB, const int M, const int N, const int K,
           const float* alpha, const float* A, const int lda, const float* B, const int ldb, const float* beta, float* C, const int ldc) {
@@ -265,6 +270,7 @@ inline void gemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA
           const Complex128* alpha, const Complex128* A, const int lda, const Complex128* B, const int ldb, const Complex128* beta, Complex128* C, const int ldc) {
   cblas_zgemm(Order, TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
 }
+#endif
 
 }} // end of namespace nm::math
 

--- a/ext/nmatrix/math/gemv.h
+++ b/ext/nmatrix/math/gemv.h
@@ -179,7 +179,7 @@ inline bool gemv(const enum CBLAS_TRANSPOSE Trans, const int M, const int N, con
   return true;
 }  // end of GEMV
 
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
 template <>
 inline bool gemv(const enum CBLAS_TRANSPOSE Trans, const int M, const int N, const float* alpha, const float* A, const int lda,
           const float* X, const int incX, const float* beta, float* Y, const int incY) {

--- a/ext/nmatrix/math/gemv.h
+++ b/ext/nmatrix/math/gemv.h
@@ -179,6 +179,7 @@ inline bool gemv(const enum CBLAS_TRANSPOSE Trans, const int M, const int N, con
   return true;
 }  // end of GEMV
 
+#ifdef HAVE_CBLAS_H
 template <>
 inline bool gemv(const enum CBLAS_TRANSPOSE Trans, const int M, const int N, const float* alpha, const float* A, const int lda,
           const float* X, const int incX, const float* beta, float* Y, const int incY) {
@@ -206,6 +207,7 @@ inline bool gemv(const enum CBLAS_TRANSPOSE Trans, const int M, const int N, con
   cblas_zgemv(CblasRowMajor, Trans, M, N, alpha, A, lda, X, incX, beta, Y, incY);
   return true;
 }
+#endif
 
 }} // end of namespace nm::math
 

--- a/ext/nmatrix/math/math.h
+++ b/ext/nmatrix/math/math.h
@@ -68,7 +68,7 @@
  * Standard Includes
  */
 
-#ifndef HAVE_CBLAS_H
+#if !(defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
 #include "cblas_enums.h"
 #endif
 
@@ -150,7 +150,7 @@ inline void herk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const
 template <>
 inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const float* alpha, const float* A, const int lda, const float* beta, float* C, const int ldc) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_ssyrk(Order, Uplo, Trans, N, K, *alpha, A, lda, *beta, C, ldc);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -160,7 +160,7 @@ inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const
 template <>
 inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const double* alpha, const double* A, const int lda, const double* beta, double* C, const int ldc) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_dsyrk(Order, Uplo, Trans, N, K, *alpha, A, lda, *beta, C, ldc);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -170,7 +170,7 @@ inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const
 template <>
 inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const Complex64* alpha, const Complex64* A, const int lda, const Complex64* beta, Complex64* C, const int ldc) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_csyrk(Order, Uplo, Trans, N, K, alpha, A, lda, beta, C, ldc);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -180,7 +180,7 @@ inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const
 template <>
 inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const Complex128* alpha, const Complex128* A, const int lda, const Complex128* beta, Complex128* C, const int ldc) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_zsyrk(Order, Uplo, Trans, N, K, alpha, A, lda, beta, C, ldc);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -191,7 +191,7 @@ inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const
 template <>
 inline void herk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const Complex64* alpha, const Complex64* A, const int lda, const Complex64* beta, Complex64* C, const int ldc) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_cherk(Order, Uplo, Trans, N, K, alpha->r, A, lda, beta->r, C, ldc);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -201,7 +201,7 @@ inline void herk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const
 template <>
 inline void herk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const Complex128* alpha, const Complex128* A, const int lda, const Complex128* beta, Complex128* C, const int ldc) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_zherk(Order, Uplo, Trans, N, K, alpha->r, A, lda, beta->r, C, ldc);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -220,7 +220,7 @@ template <>
 inline void trmm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
                  const enum CBLAS_TRANSPOSE ta, const enum CBLAS_DIAG diag, const int m, const int n, const float* alpha,
                  const float* A, const int lda, float* B, const int ldb) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_strmm(order, side, uplo, ta, diag, m, n, *alpha, A, lda, B, ldb);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -231,7 +231,7 @@ template <>
 inline void trmm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
                  const enum CBLAS_TRANSPOSE ta, const enum CBLAS_DIAG diag, const int m, const int n, const double* alpha,
                  const double* A, const int lda, double* B, const int ldb) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_dtrmm(order, side, uplo, ta, diag, m, n, *alpha, A, lda, B, ldb);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -242,7 +242,7 @@ template <>
 inline void trmm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
                  const enum CBLAS_TRANSPOSE ta, const enum CBLAS_DIAG diag, const int m, const int n, const Complex64* alpha,
                  const Complex64* A, const int lda, Complex64* B, const int ldb) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_ctrmm(order, side, uplo, ta, diag, m, n, alpha, A, lda, B, ldb);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -253,7 +253,7 @@ template <>
 inline void trmm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
                  const enum CBLAS_TRANSPOSE ta, const enum CBLAS_DIAG diag, const int m, const int n, const Complex128* alpha,
                  const Complex128* A, const int lda, Complex128* B, const int ldb) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_ztrmm(order, side, uplo, ta, diag, m, n, alpha, A, lda, B, ldb);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");

--- a/ext/nmatrix/math/math.h
+++ b/ext/nmatrix/math/math.h
@@ -68,6 +68,10 @@
  * Standard Includes
  */
 
+#ifndef HAVE_CBLAS_H
+#include "cblas_enums.h"
+#endif
+
 extern "C" { // These need to be in an extern "C" block or you'll get all kinds of undefined symbol errors.
 #if defined HAVE_CBLAS_H
   #include <cblas.h>
@@ -146,38 +150,62 @@ inline void herk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const
 template <>
 inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const float* alpha, const float* A, const int lda, const float* beta, float* C, const int ldc) {
+#ifdef HAVE_CBLAS_H
   cblas_ssyrk(Order, Uplo, Trans, N, K, *alpha, A, lda, *beta, C, ldc);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 template <>
 inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const double* alpha, const double* A, const int lda, const double* beta, double* C, const int ldc) {
+#ifdef HAVE_CBLAS_H
   cblas_dsyrk(Order, Uplo, Trans, N, K, *alpha, A, lda, *beta, C, ldc);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 template <>
 inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const Complex64* alpha, const Complex64* A, const int lda, const Complex64* beta, Complex64* C, const int ldc) {
+#ifdef HAVE_CBLAS_H
   cblas_csyrk(Order, Uplo, Trans, N, K, alpha, A, lda, beta, C, ldc);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 template <>
 inline void syrk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const Complex128* alpha, const Complex128* A, const int lda, const Complex128* beta, Complex128* C, const int ldc) {
+#ifdef HAVE_CBLAS_H
   cblas_zsyrk(Order, Uplo, Trans, N, K, alpha, A, lda, beta, C, ldc);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 
 template <>
 inline void herk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const Complex64* alpha, const Complex64* A, const int lda, const Complex64* beta, Complex64* C, const int ldc) {
+#ifdef HAVE_CBLAS_H
   cblas_cherk(Order, Uplo, Trans, N, K, alpha->r, A, lda, beta->r, C, ldc);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 template <>
 inline void herk(const enum CBLAS_ORDER Order, const enum CBLAS_UPLO Uplo, const enum CBLAS_TRANSPOSE Trans, const int N,
                  const int K, const Complex128* alpha, const Complex128* A, const int lda, const Complex128* beta, Complex128* C, const int ldc) {
+#ifdef HAVE_CBLAS_H
   cblas_zherk(Order, Uplo, Trans, N, K, alpha->r, A, lda, beta->r, C, ldc);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 
@@ -192,28 +220,44 @@ template <>
 inline void trmm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
                  const enum CBLAS_TRANSPOSE ta, const enum CBLAS_DIAG diag, const int m, const int n, const float* alpha,
                  const float* A, const int lda, float* B, const int ldb) {
+#ifdef HAVE_CBLAS_H
   cblas_strmm(order, side, uplo, ta, diag, m, n, *alpha, A, lda, B, ldb);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 template <>
 inline void trmm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
                  const enum CBLAS_TRANSPOSE ta, const enum CBLAS_DIAG diag, const int m, const int n, const double* alpha,
                  const double* A, const int lda, double* B, const int ldb) {
+#ifdef HAVE_CBLAS_H
   cblas_dtrmm(order, side, uplo, ta, diag, m, n, *alpha, A, lda, B, ldb);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 template <>
 inline void trmm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
                  const enum CBLAS_TRANSPOSE ta, const enum CBLAS_DIAG diag, const int m, const int n, const Complex64* alpha,
                  const Complex64* A, const int lda, Complex64* B, const int ldb) {
+#ifdef HAVE_CBLAS_H
   cblas_ctrmm(order, side, uplo, ta, diag, m, n, alpha, A, lda, B, ldb);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 template <>
 inline void trmm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
                  const enum CBLAS_TRANSPOSE ta, const enum CBLAS_DIAG diag, const int m, const int n, const Complex128* alpha,
                  const Complex128* A, const int lda, Complex128* B, const int ldb) {
+#ifdef HAVE_CBLAS_H
   cblas_ztrmm(order, side, uplo, ta, diag, m, n, alpha, A, lda, B, ldb);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 

--- a/ext/nmatrix/math/rot.h
+++ b/ext/nmatrix/math/rot.h
@@ -108,7 +108,7 @@ inline void rot(const int N, DType* X, const int incX, DType* Y, const int incY,
   }
 }
 
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
 template <>
 inline void rot(const int N, float* X, const int incX, float* Y, const int incY, const float c, const float s) {
   cblas_srot(N, X, incX, Y, incY, (float)c, (float)s);

--- a/ext/nmatrix/math/rot.h
+++ b/ext/nmatrix/math/rot.h
@@ -108,6 +108,7 @@ inline void rot(const int N, DType* X, const int incX, DType* Y, const int incY,
   }
 }
 
+#ifdef HAVE_CBLAS_H
 template <>
 inline void rot(const int N, float* X, const int incX, float* Y, const int incY, const float c, const float s) {
   cblas_srot(N, X, incX, Y, incY, (float)c, (float)s);
@@ -127,7 +128,7 @@ template <>
 inline void rot(const int N, Complex128* X, const int incX, Complex128* Y, const int incY, const double c, const double s) {
   cblas_zdrot(N, X, incX, Y, incY, c, s);
 }
-
+#endif
 
 template <typename DType, typename CSDType>
 inline void cblas_rot(const int N, void* X, const int incX, void* Y, const int incY, const void* c, const void* s) {

--- a/ext/nmatrix/math/rotg.h
+++ b/ext/nmatrix/math/rotg.h
@@ -84,7 +84,7 @@ inline void rotg(DType* a, DType* b, DType* c, DType* s) {
   }
 }
 
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
 template <>
 inline void rotg(float* a, float* b, float* c, float* s) {
   cblas_srotg(a, b, c, s);
@@ -98,7 +98,7 @@ inline void rotg(double* a, double* b, double* c, double* s) {
 
 template <>
 inline void rotg(Complex64* a, Complex64* b, Complex64* c, Complex64* s) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_crotg(reinterpret_cast<void*>(a), reinterpret_cast<void*>(b), reinterpret_cast<void*>(c), reinterpret_cast<void*>(s));
 #else
   rb_raise(rb_eNotImpError, "BLAS not available, and existing template requires modification for complex");
@@ -107,7 +107,7 @@ inline void rotg(Complex64* a, Complex64* b, Complex64* c, Complex64* s) {
 
 template <>
 inline void rotg(Complex128* a, Complex128* b, Complex128* c, Complex128* s) {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_zrotg(reinterpret_cast<void*>(a), reinterpret_cast<void*>(b), reinterpret_cast<void*>(c), reinterpret_cast<void*>(s));
 #else
   rb_raise(rb_eNotImpError, "BLAS not available, and existing template requires modification for complex");

--- a/ext/nmatrix/math/rotg.h
+++ b/ext/nmatrix/math/rotg.h
@@ -84,6 +84,7 @@ inline void rotg(DType* a, DType* b, DType* c, DType* s) {
   }
 }
 
+#ifdef HAVE_CBLAS_H
 template <>
 inline void rotg(float* a, float* b, float* c, float* s) {
   cblas_srotg(a, b, c, s);
@@ -93,16 +94,26 @@ template <>
 inline void rotg(double* a, double* b, double* c, double* s) {
   cblas_drotg(a, b, c, s);
 }
+#endif
 
 template <>
 inline void rotg(Complex64* a, Complex64* b, Complex64* c, Complex64* s) {
+#ifdef HAVE_CBLAS_H
   cblas_crotg(reinterpret_cast<void*>(a), reinterpret_cast<void*>(b), reinterpret_cast<void*>(c), reinterpret_cast<void*>(s));
+#else
+  rb_raise(rb_eNotImpError, "BLAS not available, and existing template requires modification for complex");
+#endif
 }
 
 template <>
 inline void rotg(Complex128* a, Complex128* b, Complex128* c, Complex128* s) {
+#ifdef HAVE_CBLAS_H
   cblas_zrotg(reinterpret_cast<void*>(a), reinterpret_cast<void*>(b), reinterpret_cast<void*>(c), reinterpret_cast<void*>(s));
+#else
+  rb_raise(rb_eNotImpError, "BLAS not available, and existing template requires modification for complex");
+#endif
 }
+
 
 template <typename DType>
 inline void cblas_rotg(void* a, void* b, void* c, void* s) {

--- a/ext/nmatrix/math/trsm.h
+++ b/ext/nmatrix/math/trsm.h
@@ -343,7 +343,7 @@ inline void trsm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const
                  const int m, const int n, const float alpha, const float* a,
                  const int lda, float* b, const int ldb)
 {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_strsm(order, side, uplo, trans_a, diag, m, n, alpha, a, lda, b, ldb);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -364,7 +364,7 @@ inline void trsm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const
        << (diag == CblasNonUnit ? "nonunit " : "unit ")
        << m << " " << n << " " << alpha << " a " << lda << " b " << ldb << endl;
 */
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_dtrsm(order, side, uplo, trans_a, diag, m, n, alpha, a, lda, b, ldb);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -378,7 +378,7 @@ inline void trsm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const
                  const int m, const int n, const Complex64 alpha, const Complex64* a,
                  const int lda, Complex64* b, const int ldb)
 {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_ctrsm(order, side, uplo, trans_a, diag, m, n, (const void*)(&alpha), (const void*)(a), lda, (void*)(b), ldb);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");
@@ -391,7 +391,7 @@ inline void trsm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const
                  const int m, const int n, const Complex128 alpha, const Complex128* a,
                  const int lda, Complex128* b, const int ldb)
 {
-#ifdef HAVE_CBLAS_H
+#if (defined(HAVE_CBLAS_H) || defined(HAVE_ATLAS_CBLAS_H))
   cblas_ztrsm(order, side, uplo, trans_a, diag, m, n, (const void*)(&alpha), (const void*)(a), lda, (void*)(b), ldb);
 #else
   rb_raise(rb_eNotImpError, "BLAS not linked");

--- a/ext/nmatrix/math/trsm.h
+++ b/ext/nmatrix/math/trsm.h
@@ -343,7 +343,11 @@ inline void trsm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const
                  const int m, const int n, const float alpha, const float* a,
                  const int lda, float* b, const int ldb)
 {
+#ifdef HAVE_CBLAS_H
   cblas_strsm(order, side, uplo, trans_a, diag, m, n, alpha, a, lda, b, ldb);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 template <>
@@ -360,7 +364,11 @@ inline void trsm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const
        << (diag == CblasNonUnit ? "nonunit " : "unit ")
        << m << " " << n << " " << alpha << " a " << lda << " b " << ldb << endl;
 */
+#ifdef HAVE_CBLAS_H
   cblas_dtrsm(order, side, uplo, trans_a, diag, m, n, alpha, a, lda, b, ldb);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 
@@ -370,7 +378,11 @@ inline void trsm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const
                  const int m, const int n, const Complex64 alpha, const Complex64* a,
                  const int lda, Complex64* b, const int ldb)
 {
+#ifdef HAVE_CBLAS_H
   cblas_ctrsm(order, side, uplo, trans_a, diag, m, n, (const void*)(&alpha), (const void*)(a), lda, (void*)(b), ldb);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 template <>
@@ -379,7 +391,11 @@ inline void trsm(const enum CBLAS_ORDER order, const enum CBLAS_SIDE side, const
                  const int m, const int n, const Complex128 alpha, const Complex128* a,
                  const int lda, Complex128* b, const int ldb)
 {
+#ifdef HAVE_CBLAS_H
   cblas_ztrsm(order, side, uplo, trans_a, diag, m, n, (const void*)(&alpha), (const void*)(a), lda, (void*)(b), ldb);
+#else
+  rb_raise(rb_eNotImpError, "BLAS not linked");
+#endif
 }
 
 


### PR DESCRIPTION
NMatrix has a lot of functionalities that people should be able to use even if CBLAS is unavailable. These changes fix compiling and linking in cases where a user comments out the cblas-finding lines in extconf.rb. With some more work, they should allow for a more robust installation process.

Relates to #69.