### PR TITLE
Fix count not being set correctly on dense storage structs.

### DIFF
--- a/ext/nmatrix/storage/dense/dense.cpp
+++ b/ext/nmatrix/storage/dense/dense.cpp
@@ -213,7 +213,7 @@ static DENSE_STORAGE* nm_dense_storage_create_dummy(nm::dtype_t dtype, size_t* s
   memset(s->offset, 0, sizeof(size_t)*dim);
 
   s->stride     = stride(shape, dim);
-  s->count      = 1;
+  s->count      = 0;
   s->src        = s;
 
 	s->elements   = NULL;
@@ -237,13 +237,15 @@ DENSE_STORAGE* nm_dense_storage_create(nm::dtype_t dtype, size_t* shape, size_t 
 
   if (elements_length == count) {
     s->elements = elements;
-    
+    s->count = count;
+
     if (dtype == nm::RUBYOBJ)
       nm_unregister_values(reinterpret_cast<VALUE*>(elements), elements_length);
 
   } else {
 
     s->elements = NM_ALLOC_N(char, DTYPE_SIZES[dtype]*count);
+    s->count = count;
 
     if (dtype == nm::RUBYOBJ)
       nm_unregister_values(reinterpret_cast<VALUE*>(elements), elements_length);


### PR DESCRIPTION
(Fixes #356).

I have no idea why I had count set to 1 originally and then never updated it.
It should be 0 while elements is NULL (since there are no elements at all),
and then updated to the correct number in nm_dense_storage_create, when
elements is actually set to something.

An alternate strategy considered was to set count to the value returned by
nm_storage_count_max_elements in nm_dense_storage_create_dummy itself, but this
seemed more likely to cause a segfault down the road to me (since it might be
likely to iterate over elements from 0 to count).