### PR TITLE
NArray compatibility

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -82,6 +82,16 @@ matrix, {read the guide in our wiki}[https://github.com/SciRuby/nmatrix/wiki/How
 
 Again, you can find the complete API documentation {on our website}[http://sciruby.com/nmatrix/docs/].
 
+== NArray Compatibility
+
+When NArray[http://masa16.github.io/narray/] is installed alongside NMatrix, <tt>require 'nmatrix'</tt>
+will inadvertently load NArray's +lib/nmatrix.rb+ file, usually accompanied by the following error:
+
+    uninitialized constant NArray (NameError)
+
+To make sure NMatrix is loaded properly in the presence of NArray, use <tt>require 'nmatrix/nmatrix'</tt>
+instead of <tt>require 'nmatrix'</tt> in your code.
+
 == Developers
 
 Read the instructions in +CONTRIBUTING.md+ if you want to help NMatrix.

--- a/lib/nmatrix.rb
+++ b/lib/nmatrix.rb
@@ -22,7 +22,7 @@
 #
 # == nmatrix.rb
 #
-# This file loads the C extension for NMatrix and all the ruby files.
+# This file is a stub that only loads the main NMatrix file.
 #
 
 require 'nmatrix/nmatrix.rb'

--- a/lib/nmatrix.rb
+++ b/lib/nmatrix.rb
@@ -25,22 +25,4 @@
 # This file loads the C extension for NMatrix and all the ruby files.
 #
 
-# For some reason nmatrix.so ends up in a different place during gem build.
-if File.exist?("lib/nmatrix/nmatrix.so") #|| File.exist?("lib/nmatrix/nmatrix.bundle")
-  # Development
-  require "nmatrix/nmatrix.so"
-else
-  # Gem
-  require "nmatrix.so"
-end
-
-require 'nmatrix/io/mat_reader'
-require 'nmatrix/io/mat5_reader'
-require 'nmatrix/io/market'
-require 'nmatrix/io/point_cloud'
-
 require 'nmatrix/nmatrix.rb'
-require 'nmatrix/version.rb'
-require 'nmatrix/blas.rb'
-require 'nmatrix/monkeys'
-require "nmatrix/shortcuts.rb"

--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -28,6 +28,20 @@
 # inspect, pretty_print, element-wise operations).
 #++
 
+# For some reason nmatrix.so ends up in a different place during gem build.
+if File.exist?("lib/nmatrix/nmatrix.so") #|| File.exist?("lib/nmatrix/nmatrix.bundle")
+  # Development
+  require "nmatrix/nmatrix.so"
+else
+  # Gem
+  require "nmatrix.so"
+end
+
+require 'nmatrix/io/mat_reader'
+require 'nmatrix/io/mat5_reader'
+require 'nmatrix/io/market'
+require 'nmatrix/io/point_cloud'
+
 require_relative './lapack.rb'
 require_relative './yale_functions.rb'
 require_relative './monkeys'
@@ -1117,3 +1131,8 @@ end
 require_relative './shortcuts.rb'
 require_relative './math.rb'
 require_relative './enumerate.rb'
+
+require 'nmatrix/version.rb'
+require 'nmatrix/blas.rb'
+require 'nmatrix/monkeys'
+require "nmatrix/shortcuts.rb"

--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -37,10 +37,10 @@ else
   require "nmatrix.so"
 end
 
-require 'nmatrix/io/mat_reader'
-require 'nmatrix/io/mat5_reader'
-require 'nmatrix/io/market'
-require 'nmatrix/io/point_cloud'
+require_relative './io/mat_reader'
+require_relative './io/mat5_reader'
+require_relative './io/market'
+require_relative './io/point_cloud'
 
 require_relative './lapack.rb'
 require_relative './yale_functions.rb'
@@ -1132,7 +1132,5 @@ require_relative './shortcuts.rb'
 require_relative './math.rb'
 require_relative './enumerate.rb'
 
-require 'nmatrix/version.rb'
-require 'nmatrix/blas.rb'
-require 'nmatrix/monkeys'
-require "nmatrix/shortcuts.rb"
+require_relative './version.rb'
+require_relative './blas.rb'

--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -23,7 +23,8 @@
 #
 # == nmatrix.rb
 #
-# This file contains those core functionalities which can be
+# This file loads the C extension for NMatrix and all the ruby
+# files and contains those core functionalities which can be
 # implemented efficiently (or much more easily) in Ruby (e.g.,
 # inspect, pretty_print, element-wise operations).
 #++


### PR DESCRIPTION
When NArray is installed alongside NMatrix, `require 'nmatrix'` will load NArray's `lib/nmatrix.rb` file. By moving all relevant code from NMatrix's `lib/nmatrix.rb` to `lib/nmatrix/nmatrix.rb`, users can `require 'nmatrix/nmatrix'` to load NMatrix and thus bypass NArray. (Related issues: SciRuby/nmatrix#6, SciRuby/nmatrix#172 and masa16/narray#39; also SciRuby/rb-gsl#14)

* The order in which code was loaded previously has been preserved.
* I have cleaned up the newly added `require`s in an extra commit.
* I have also included documentation changes in extra commits. Feel free to ignore.

Please note that I didn't go the extra mile and set up a test environment locally. I trust that it continues to work, based on the nature of the changes, and let Travis do the rest.