### PR TITLE
Fix determinant calculation, add specs (issue #368)

### DIFF
--- a/ext/nmatrix/math.cpp
+++ b/ext/nmatrix/math.cpp
@@ -234,6 +234,12 @@ namespace nm {
       }
     }
 
+    //we can't do det_exact on byte, because it will want to return a byte (unsigned), but determinants can be negative, even if all elements of the matrix are positive
+    template <>
+    void det_exact<uint8_t>(const int M, const void* A_elements, const int lda, void* result_arg) {
+      rb_raise(nm_eDataTypeError, "cannot call det_exact on unsigned type");
+    }
+
     /*
      * Solve a system of linear equations using forward-substution followed by 
      * back substution from the LU factorization of the matrix of co-efficients.

--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -455,7 +455,11 @@ class NMatrix
     # the factorized matrix.
     pivot = copy.getrf!
 
-    prod = pivot.size % 2 == 1 ? -1 : 1 # odd permutations => negative
+    num_perm = 0 #number of permutations
+    pivot.each_with_index do |swap, i|
+      num_perm += 1 if swap != i
+    end
+    prod = num_perm % 2 == 1 ? -1 : 1 # odd permutations => negative
     [shape[0],shape[1]].min.times do |i|
       prod *= copy[i,i]
     end

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -614,4 +614,54 @@ describe "math" do
       end
     end
   end
+
+  context "determinants" do
+    ALL_DTYPES.each do |dtype|
+      next if dtype == :object
+      context dtype do
+        before do
+          @a = NMatrix.new([2,2], [1,2,
+                                   3,4], dtype: dtype)
+          @b = NMatrix.new([3,3], [1,2,3,
+                                   5,0,1,
+                                   4,1,3], dtype: dtype)
+          @c = NMatrix.new([4,4], [1, 0, 1, 1,
+                                   1, 2, 3, 1,
+                                   3, 3, 3, 1,
+                                   1, 2, 3, 4], dtype: dtype)
+          @err = case dtype
+                  when :float32, :complex64
+                    1e-6
+                  when :float64, :complex128
+                    1e-15
+                  else
+                    1e-64 # FIXME: should be 0, but be_within(0) does not work.
+                end
+        end
+        it "computes the determinant of 2x2 matrix" do
+          expect(@a.det).to be_within(@err).of(-2)
+        end
+        it "computes the determinant of 3x3 matrix" do
+          expect(@b.det).to be_within(@err).of(-8)
+        end
+        it "computes the determinant of 4x4 matrix" do
+          expect(@c.det).to be_within(@err).of(-18)
+        end
+        it "computes the exact determinant of 2x2 matrix" do
+          if dtype == :byte
+            expect{@a.det_exact}.to raise_error(DataTypeError)
+          else
+            expect(@a.det_exact).to be_within(@err).of(-2)
+          end
+        end
+        it "computes the exact determinant of 3x3 matrix" do
+          if dtype == :byte
+            expect{@a.det_exact}.to raise_error(DataTypeError)
+          else
+            expect(@b.det_exact).to be_within(@err).of(-8)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
There were already a couple of tests for det in 00_nmatrix_spec.rb, but obviously not enough, so I added some more.

The tests currently fail. This is because the return value of det_exact is always the same dtype of the matrix, so it fails for :byte if the determinant is negative. Not sure what to do about this.