### PR TITLE
Fix asum for single element complex matrices

### DIFF
--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -791,7 +791,10 @@ class NMatrix
   #
   # Return the sum of the contents of the vector. This is the BLAS asum routine.
   def asum incx=1, n=nil
-    return self[0].abs if self.shape == [1]
+    if self.shape == [1]
+      return self[0].abs unless self.complex_dtype?
+      return self[0].real.abs + self[0].imag.abs
+    end
     return method_missing(:asum, incx, n) unless vector?
     NMatrix::BLAS::asum(self, incx, self.size / incx)
   end

--- a/spec/blas_spec.rb
+++ b/spec/blas_spec.rb
@@ -152,8 +152,13 @@ describe NMatrix::BLAS do
       end
 
       it "exposes asum for single element" do
-        x = NMatrix.new([1], [-1], dtype: :float64)
-        expect(x.asum).to eq(1.0)
+        if [:complex64,:complex128].include?(dtype)
+          x = NMatrix.new([1], [Complex(-3,2)], dtype: dtype)
+          expect(x.asum).to eq(5.0)
+        else
+          x = NMatrix.new([1], [-1], dtype: dtype)
+          expect(x.asum).to eq(1.0)
+        end
       end
 
       it "exposes nrm2" do


### PR DESCRIPTION
For complex matrices, asum is supposed to return "the sum of magnitudes of the real and imaginary parts of elements of a complex vector" (https://software.intel.com/en-us/node/520731). This works most of the time, but not for vectors with just a single element, which is special cased in the code.