### PR TITLE
Revert "Fix count not being set correctly on dense storage structs."

### DIFF
--- a/ext/nmatrix/storage/dense/dense.cpp
+++ b/ext/nmatrix/storage/dense/dense.cpp
@@ -213,7 +213,7 @@ static DENSE_STORAGE* nm_dense_storage_create_dummy(nm::dtype_t dtype, size_t* s
   memset(s->offset, 0, sizeof(size_t)*dim);
 
   s->stride     = stride(shape, dim);
-  s->count      = 0;
+  s->count      = 1;
   s->src        = s;
 
 	s->elements   = NULL;
@@ -237,15 +237,13 @@ DENSE_STORAGE* nm_dense_storage_create(nm::dtype_t dtype, size_t* shape, size_t 
 
   if (elements_length == count) {
     s->elements = elements;
-    s->count = count;
-
+    
     if (dtype == nm::RUBYOBJ)
       nm_unregister_values(reinterpret_cast<VALUE*>(elements), elements_length);
 
   } else {
 
     s->elements = NM_ALLOC_N(char, DTYPE_SIZES[dtype]*count);
-    s->count = count;
 
     if (dtype == nm::RUBYOBJ)
       nm_unregister_values(reinterpret_cast<VALUE*>(elements), elements_length);


### PR DESCRIPTION
This reverts commit a66a790247e94f1ba13dc1dfea11497f6267db20.

This is a reference count and not an element count.  Fixes #377.