### PR TITLE
Rename local variable "count" to "storage_element_count" in `nm_dense…

### DIFF
--- a/ext/nmatrix/storage/dense/dense.cpp
+++ b/ext/nmatrix/storage/dense/dense.cpp
@@ -233,17 +233,17 @@ DENSE_STORAGE* nm_dense_storage_create(nm::dtype_t dtype, size_t* shape, size_t 
     nm_register_values(reinterpret_cast<VALUE*>(elements), elements_length);
 
   DENSE_STORAGE* s = nm_dense_storage_create_dummy(dtype, shape, dim);
-  size_t count  = nm_storage_count_max_elements(s);
+  size_t storage_element_count  = nm_storage_count_max_elements(s);
 
-  if (elements_length == count) {
+  if (elements_length == storage_element_count) {
     s->elements = elements;
-    
+
     if (dtype == nm::RUBYOBJ)
       nm_unregister_values(reinterpret_cast<VALUE*>(elements), elements_length);
 
   } else {
 
-    s->elements = NM_ALLOC_N(char, DTYPE_SIZES[dtype]*count);
+    s->elements = NM_ALLOC_N(char, DTYPE_SIZES[dtype]*storage_element_count);
 
     if (dtype == nm::RUBYOBJ)
       nm_unregister_values(reinterpret_cast<VALUE*>(elements), elements_length);
@@ -252,10 +252,10 @@ DENSE_STORAGE* nm_dense_storage_create(nm::dtype_t dtype, size_t* shape, size_t 
 
     if (elements_length > 0) {
       // Repeat elements over and over again until the end of the matrix.
-      for (size_t i = 0; i < count; i += elements_length) {
+      for (size_t i = 0; i < storage_element_count; i += elements_length) {
 
-        if (i + elements_length > count) {
-        	copy_length = count - i;
+        if (i + elements_length > storage_element_count) {
+          copy_length = storage_element_count - i;
         }
 
         memcpy((char*)(s->elements)+i*DTYPE_SIZES[dtype], (char*)(elements)+(i % elements_length)*DTYPE_SIZES[dtype], copy_length*DTYPE_SIZES[dtype]);


### PR DESCRIPTION
…_storage_create`

This will hopefully help to avoid the confusion seen in #356 about this not
being the same thing as the count field on the storage structure that led to
the bug in #377.

(We might potentially rename count to refcount in the storage structure for
additional clarity, but that's a bit of a bigger change, since it's part of the storage structure declaratations.)