### PR TITLE
Fix #==, add specs

### DIFF
--- a/ext/nmatrix/storage/dense/dense.cpp
+++ b/ext/nmatrix/storage/dense/dense.cpp
@@ -983,6 +983,16 @@ bool eqeq(const DENSE_STORAGE* left, const DENSE_STORAGE* right) {
     return false;
   }
 
+  size_t dim = left->dim;
+  for (size_t i=0; i<dim; i++) {
+    if (left->shape[i] != right->shape[i]) {
+      nm_dense_storage_unregister(right);
+      nm_dense_storage_unregister(left);
+
+      return false;
+    }
+  }
+
   LDType* left_elements	  = (LDType*)left->elements;
   RDType* right_elements  = (RDType*)right->elements;
 

--- a/ext/nmatrix/storage/list/list.cpp
+++ b/ext/nmatrix/storage/list/list.cpp
@@ -1318,6 +1318,13 @@ void nm_list_storage_remove(STORAGE* storage, SLICE* slice) {
 bool nm_list_storage_eqeq(const STORAGE* left, const STORAGE* right) {
 	NAMED_LR_DTYPE_TEMPLATE_TABLE(ttable, nm::list_storage::eqeq_r, bool, nm::list_storage::RecurseData& left, nm::list_storage::RecurseData& right, const LIST* l, const LIST* r, size_t rec)
 
+  // Check that the shapes match before going any further.
+  if (left->dim != right->dim) return false;
+  size_t dim = left->dim;
+  for (size_t i=0; i<dim; i++) {
+    if (left->shape[i] != right->shape[i]) return false;
+  }
+
   nm::list_storage::RecurseData ldata(reinterpret_cast<const LIST_STORAGE*>(left)),
                                 rdata(reinterpret_cast<const LIST_STORAGE*>(right));
 

--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -1077,8 +1077,6 @@ protected
   end
 
 
-  # Function assumes the dimensions and such have already been tested.
-  #
   # Called from inside NMatrix: nm_eqeq
   #
   # There are probably more efficient ways to do this, but currently it's unclear how.
@@ -1089,6 +1087,8 @@ protected
   # cast and then run the comparison. For now, let's assume that people aren't going
   # to be doing this very often, and we can optimize as needed.
   def dense_eql_sparse? m #:nodoc:
+    return false if self.shape != m.shape
+
     m.each_with_indices do |v,*indices|
       return false if self[*indices] != v
     end

--- a/spec/00_nmatrix_spec.rb
+++ b/spec/00_nmatrix_spec.rb
@@ -478,13 +478,38 @@ describe 'NMatrix' do
   context "#==" do
     [:dense, :list, :yale].each do |left|
       [:dense, :list, :yale].each do |right|
-        next if left == right
         context ("#{left}?#{right}") do
-          it "should compare two matrices of differing stypes" do
-            n = NMatrix.new([3,4], [0,0,1,2,0,0,3,4,0,0,0,0,5,6,7,0], stype: left)
-            m = NMatrix.new([3,4], [0,0,1,2,0,0,3,4,0,0,0,0,5,6,7,0], stype: right)
-            expect(n).to eq(m)
+          it "tests equality of two equal matrices" do
+            n = NMatrix.new([3,4], [0,0,1,2,0,0,3,4,0,0,0,0], stype: left)
+            m = NMatrix.new([3,4], [0,0,1,2,0,0,3,4,0,0,0,0], stype: right)
+
+            expect(n==m).to eq(true)
+            expect(m==n).to eq(true)
           end
+
+          it "tests equality of two unequal matrices" do
+            n = NMatrix.new([3,4], [0,0,1,2,0,0,3,4,0,0,0,1], stype: left)
+            m = NMatrix.new([3,4], [0,0,1,2,0,0,3,4,0,0,0,0], stype: right)
+
+            expect(n==m).to eq(false)
+            expect(m==n).to eq(false)
+          end
+
+          it "tests equality of matrices with different shapes" do
+            n = NMatrix.new([2,2], [1,2, 3,4], stype: left)
+            m = NMatrix.new([2,3], [1,2, 3,4, 5,6], stype: right)
+
+            expect(n==m).to eq(false)
+            expect(m==n).to eq(false)
+          end
+
+          it "tests equality of matrices with different dimension" do
+            n = NMatrix.new([2,1], [1,2], stype: left)
+            m = NMatrix.new([2], [1,2], stype: right)
+
+            expect(n==m).to eq(false)
+            expect(m==n).to eq(false)
+          end if left != :yale && right != :yale
         end
       end
     end

--- a/spec/03_nmatrix_monkeys_spec.rb
+++ b/spec/03_nmatrix_monkeys_spec.rb
@@ -59,7 +59,7 @@ describe Array do
 
     it "intuits shape of Array into multiple dimensions" do
       a = [[[0], [1]], [[2], [3]], [[4], [5]]]
-      expect(a.to_nm).to eq(NMatrix.new([3,1,2], a.flatten))
+      expect(a.to_nm).to eq(NMatrix.new([3,2,1], a.flatten))
       expect(a).to eq(a.to_nm.to_a)
     end
 


### PR DESCRIPTION
This fixes #391, but the specs I wrote reveal another bug which is a segfault when testing the equality two list matrices with different shapes. I honestly do not understand the [list code for ==](https://github.com/SciRuby/nmatrix/blob/master/ext/nmatrix/storage/list/list.cpp#L1541) at all, so if someone else could take a look at this, or at least point me in the right direction, that would be great.