### PR TITLE
Supporting to build by clang

### DIFF
--- a/ext/nmatrix/data/complex.h
+++ b/ext/nmatrix/data/complex.h
@@ -77,18 +77,18 @@ class Complex {
 	 */
 	inline Complex(Type real = 0, Type imaginary = 0) : r(real), i(imaginary) {}
 
-	/*
-	 * Copy constructors.
-	 */
-	template <typename ComplexType>
-	explicit inline Complex(const Complex<ComplexType>& other) : r(other.r), i(other.i) {}
+  /*
+   * Copy constructors.
+   */
+  template <typename ComplexType>
+  explicit inline Complex(const Complex<ComplexType>& other) : r(other.r), i(other.i) {}
 
-        template <typename ComplexType>
-        inline Complex<Type>& operator=(const Complex<ComplexType>& other) {
-          this->r = static_cast<Type>(other.r);
-          this->i = static_cast<Type>(other.i);
-          return *this;
-        }
+  template <typename ComplexType>
+  inline Complex<Type>& operator=(const Complex<ComplexType>& other) {
+    this->r = static_cast<Type>(other.r);
+    this->i = static_cast<Type>(other.i);
+    return *this;
+  }
 
   explicit Complex(const RubyObject& other);
 
@@ -288,7 +288,7 @@ class Complex {
 		return (NativeType)this->r;
 	}
 
-        operator RubyObject () const;
+  operator RubyObject () const;
 };
 
 ///////////////////////////////

--- a/ext/nmatrix/data/complex.h
+++ b/ext/nmatrix/data/complex.h
@@ -103,6 +103,11 @@ class Complex {
     return Complex<Type>(conj.r / denom, conj.i / denom);
   }
 
+  // Negative operator
+  inline Complex<Type> operator-() const {
+    return Complex<Type>(-this->r, -this->i);
+  }
+
 
 
 	/*

--- a/ext/nmatrix/data/complex.h
+++ b/ext/nmatrix/data/complex.h
@@ -81,9 +81,25 @@ class Complex {
 	 * Copy constructors.
 	 */
 	template <typename ComplexType>
-	inline Complex(const Complex<ComplexType>& other) : r(other.r), i(other.i) {}
+	explicit inline Complex(const Complex<ComplexType>& other) : r(other.r), i(other.i) {}
 
-  Complex(const RubyObject& other);
+        template <typename ComplexType>
+        inline Complex<Type>& operator=(const Complex<ComplexType>& other) {
+          this->r = static_cast<Type>(other.r);
+          this->i = static_cast<Type>(other.i);
+          return *this;
+        }
+
+  explicit Complex(const RubyObject& other);
+
+  Complex<Type>& operator=(const RubyObject& other);
+
+  template<typename OtherType>
+  inline Complex<Type>& operator=(const OtherType& real) {
+    this->r = Type(real);
+    this->i = Type(0);
+    return *this;
+  }
 
   /*
    * Complex conjugate function -- creates a copy, but inverted.
@@ -271,6 +287,8 @@ class Complex {
 	inline operator NativeType () const {
 		return (NativeType)this->r;
 	}
+
+        operator RubyObject () const;
 };
 
 ///////////////////////////////

--- a/ext/nmatrix/data/data.cpp
+++ b/ext/nmatrix/data/data.cpp
@@ -91,6 +91,53 @@ namespace nm {
     "negate", "floor", "ceil", "round"
   };
 
+
+  /*
+   * Create a RubyObject from a regular C value (given a dtype). Does not return a VALUE! To get a VALUE, you need to
+   * look at the rval property of what this function returns.
+   */
+  nm::RubyObject rubyobj_from_cval(void* val, nm::dtype_t dtype) {
+    using namespace nm;
+    switch (dtype) {
+      case BYTE:
+        return RubyObject(*reinterpret_cast<uint8_t*>(val));
+
+      case INT8:
+        return RubyObject(*reinterpret_cast<int8_t*>(val));
+
+      case INT16:
+        return RubyObject(*reinterpret_cast<int16_t*>(val));
+
+      case INT32:
+        return RubyObject(*reinterpret_cast<int32_t*>(val));
+
+      case INT64:
+        return RubyObject(*reinterpret_cast<int64_t*>(val));
+
+      case FLOAT32:
+        return RubyObject(*reinterpret_cast<float32_t*>(val));
+
+      case FLOAT64:
+        return RubyObject(*reinterpret_cast<float64_t*>(val));
+
+      case COMPLEX64:
+        return RubyObject(*reinterpret_cast<Complex64*>(val));
+
+      case COMPLEX128:
+        return RubyObject(*reinterpret_cast<Complex128*>(val));
+
+      default:
+        try {
+          throw std::logic_error("Cannot create ruby object");
+        }
+        catch (std::logic_error err) {
+          printf("%s\n", err.what());
+        }
+
+        rb_raise(nm_eDataTypeError, "Conversion to RubyObject requested from unknown/invalid data type (did you try to convert from a VALUE?)");
+    }
+    return Qnil;
+  }
 } // end of namespace nm
 
 extern "C" {
@@ -198,52 +245,6 @@ void rubyval_to_cval(VALUE val, nm::dtype_t dtype, void* loc) {
 	}
 }
 
-/*
- * Create a RubyObject from a regular C value (given a dtype). Does not return a VALUE! To get a VALUE, you need to
- * look at the rval property of what this function returns.
- */
-nm::RubyObject rubyobj_from_cval(void* val, nm::dtype_t dtype) {
-  using namespace nm;
-	switch (dtype) {
-		case BYTE:
-			return RubyObject(*reinterpret_cast<uint8_t*>(val));
-
-		case INT8:
-			return RubyObject(*reinterpret_cast<int8_t*>(val));
-
-		case INT16:
-			return RubyObject(*reinterpret_cast<int16_t*>(val));
-
-		case INT32:
-			return RubyObject(*reinterpret_cast<int32_t*>(val));
-
-		case INT64:
-			return RubyObject(*reinterpret_cast<int64_t*>(val));
-
-		case FLOAT32:
-			return RubyObject(*reinterpret_cast<float32_t*>(val));
-
-		case FLOAT64:
-			return RubyObject(*reinterpret_cast<float64_t*>(val));
-
-		case COMPLEX64:
-			return RubyObject(*reinterpret_cast<Complex64*>(val));
-
-		case COMPLEX128:
-			return RubyObject(*reinterpret_cast<Complex128*>(val));
-			
-	  default:
-	  	try {
-	  		throw std::logic_error("Cannot create ruby object");
-	  	}
-	  	catch (std::logic_error err) {
-	  		printf("%s\n", err.what());
-	  	}
-
-	    rb_raise(nm_eDataTypeError, "Conversion to RubyObject requested from unknown/invalid data type (did you try to convert from a VALUE?)");
-	}
-	return Qnil;
-}
 
 
 

--- a/ext/nmatrix/data/data.h
+++ b/ext/nmatrix/data/data.h
@@ -114,20 +114,31 @@ namespace nm {
 
   template <typename Type>
   Complex<Type>::Complex(const RubyObject& other) {
+    *this = other;
+  }
+
+  template <typename Type>
+  Complex<Type>& Complex<Type>::operator=(const RubyObject& other) {
     switch(TYPE(other.rval)) {
     case T_COMPLEX:
-      r = NUM2DBL(rb_funcall(other.rval, rb_intern("real"), 0));
-      i = NUM2DBL(rb_funcall(other.rval, rb_intern("imag"), 0));
+      this->r = NUM2DBL(rb_funcall(other.rval, rb_intern("real"), 0));
+      this->i = NUM2DBL(rb_funcall(other.rval, rb_intern("imag"), 0));
       break;
     case T_FLOAT:
     case T_FIXNUM:
     case T_BIGNUM:
-      r = NUM2DBL(other.rval);
-      i = 0.0;
+      this->r = NUM2DBL(other.rval);
+      this->i = 0.0;
       break;
     default:
       rb_raise(rb_eTypeError, "not sure how to convert this type of VALUE to a complex");
     }
+    return *this;
+  }
+
+  template<typename Type>
+  Complex<Type>::operator RubyObject () const {
+    return RubyObject(*this);
   }
 
   nm::RubyObject	rubyobj_from_cval(void* val, nm::dtype_t dtype);

--- a/ext/nmatrix/data/data.h
+++ b/ext/nmatrix/data/data.h
@@ -129,6 +129,8 @@ namespace nm {
       rb_raise(rb_eTypeError, "not sure how to convert this type of VALUE to a complex");
     }
   }
+
+  nm::RubyObject	rubyobj_from_cval(void* val, nm::dtype_t dtype);
 } // end of namespace nm
 
 /*
@@ -629,7 +631,6 @@ extern const nm::dtype_t Upcast[nm::NUM_DTYPES][nm::NUM_DTYPES];
 
 void*	    			rubyobj_to_cval(VALUE val, nm::dtype_t dtype);
 void  		  		rubyval_to_cval(VALUE val, nm::dtype_t dtype, void* loc);
-nm::RubyObject	rubyobj_from_cval(void* val, nm::dtype_t dtype);
 
 void nm_init_data();
 

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -105,9 +105,6 @@ basenames = %w{nmatrix ruby_constants data/data util/io math util/sl_list storag
 $objs = basenames.map { |b| "#{b}.o"   }
 $srcs = basenames.map { |b| "#{b}.cpp" }
 
-#CONFIG['CXX'] = 'clang++'
-CONFIG['CXX'] = 'g++'
-
 def find_newer_gplusplus #:nodoc:
   print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
   [9,8,7,6,5,4,3].each do |minor|

--- a/ext/nmatrix/math.cpp
+++ b/ext/nmatrix/math.cpp
@@ -599,8 +599,8 @@ static VALUE nm_cblas_rotg(VALUE self, VALUE ab) {
       rb_ary_store(result, 0, *reinterpret_cast<VALUE*>(pC));
       rb_ary_store(result, 1, *reinterpret_cast<VALUE*>(pS));
     } else {
-      rb_ary_store(result, 0, rubyobj_from_cval(pC, dtype).rval);
-      rb_ary_store(result, 1, rubyobj_from_cval(pS, dtype).rval);
+      rb_ary_store(result, 0, nm::rubyobj_from_cval(pC, dtype).rval);
+      rb_ary_store(result, 1, nm::rubyobj_from_cval(pS, dtype).rval);
     }
     NM_CONSERVATIVE(nm_unregister_value(&ab));
     NM_CONSERVATIVE(nm_unregister_value(&self));
@@ -724,7 +724,7 @@ static VALUE nm_cblas_nrm2(VALUE self, VALUE n, VALUE x, VALUE incx) {
 
     ttable[dtype](FIX2INT(n), NM_STORAGE_DENSE(x)->elements, FIX2INT(incx), Result);
 
-    return rubyobj_from_cval(Result, rdtype).rval;
+    return nm::rubyobj_from_cval(Result, rdtype).rval;
   }
 }
 
@@ -773,7 +773,7 @@ static VALUE nm_cblas_asum(VALUE self, VALUE n, VALUE x, VALUE incx) {
 
   ttable[dtype](FIX2INT(n), NM_STORAGE_DENSE(x)->elements, FIX2INT(incx), Result);
 
-  return rubyobj_from_cval(Result, rdtype).rval;
+  return nm::rubyobj_from_cval(Result, rdtype).rval;
 }
 
 /*

--- a/ext/nmatrix/math/math.h
+++ b/ext/nmatrix/math/math.h
@@ -72,6 +72,7 @@
 
 #include <algorithm> // std::min, std::max
 #include <limits> // std::numeric_limits
+#include <memory> // std::unique_ptr
 
 /*
  * Project Includes
@@ -123,8 +124,8 @@ template <typename DType>
 inline void numbmm(const unsigned int n, const unsigned int m, const unsigned int l, const IType* ia, const IType* ja, const DType* a, const bool diaga,
             const IType* ib, const IType* jb, const DType* b, const bool diagb, IType* ic, IType* jc, DType* c, const bool diagc) {
   const unsigned int max_lmn = std::max(std::max(m, n), l);
-  IType next[max_lmn];
-  DType sums[max_lmn];
+  std::unique_ptr<IType[]> next(new IType[max_lmn]);
+  std::unique_ptr<DType[]> sums(new DType[max_lmn]);
 
   DType v;
 

--- a/ext/nmatrix/ruby_nmatrix.c
+++ b/ext/nmatrix/ruby_nmatrix.c
@@ -2266,7 +2266,7 @@ static VALUE nm_xslice(int argc, VALUE* argv, void* (*slice_func)(const STORAGE*
       };
 
       if (NM_DTYPE(self) == nm::RUBYOBJ)  result = *reinterpret_cast<VALUE*>( ttable[NM_STYPE(self)](s, slice) );
-      else                                result = rubyobj_from_cval( ttable[NM_STYPE(self)](s, slice), NM_DTYPE(self) ).rval;
+      else                                result = nm::rubyobj_from_cval( ttable[NM_STYPE(self)](s, slice), NM_DTYPE(self) ).rval;
 
     } else {
 
@@ -3047,7 +3047,7 @@ static VALUE nm_det_exact(VALUE self) {
   if (dtype == nm::RUBYOBJ) {
     nm_register_values(reinterpret_cast<VALUE*>(result), 1);
   }
-  VALUE to_return = rubyobj_from_cval(result, NM_DTYPE(self)).rval;
+  VALUE to_return = nm::rubyobj_from_cval(result, NM_DTYPE(self)).rval;
   if (dtype == nm::RUBYOBJ) {
     nm_unregister_values(reinterpret_cast<VALUE*>(result), 1);
   }

--- a/ext/nmatrix/storage/dense/dense.cpp
+++ b/ext/nmatrix/storage/dense/dense.cpp
@@ -390,9 +390,9 @@ VALUE nm_dense_map_pair(VALUE self, VALUE right) {
     size_t s_index = nm_dense_storage_pos(s, coords),
            t_index = nm_dense_storage_pos(t, coords);
 
-    VALUE sval = NM_DTYPE(self) == nm::RUBYOBJ ? reinterpret_cast<VALUE*>(s->elements)[s_index] : rubyobj_from_cval((char*)(s->elements) + s_index*DTYPE_SIZES[NM_DTYPE(self)], NM_DTYPE(self)).rval;
+    VALUE sval = NM_DTYPE(self) == nm::RUBYOBJ ? reinterpret_cast<VALUE*>(s->elements)[s_index] : nm::rubyobj_from_cval((char*)(s->elements) + s_index*DTYPE_SIZES[NM_DTYPE(self)], NM_DTYPE(self)).rval;
     nm_register_value(&sval);
-    VALUE tval = NM_DTYPE(right) == nm::RUBYOBJ ? reinterpret_cast<VALUE*>(t->elements)[t_index] : rubyobj_from_cval((char*)(t->elements) + t_index*DTYPE_SIZES[NM_DTYPE(right)], NM_DTYPE(right)).rval;
+    VALUE tval = NM_DTYPE(right) == nm::RUBYOBJ ? reinterpret_cast<VALUE*>(t->elements)[t_index] : nm::rubyobj_from_cval((char*)(t->elements) + t_index*DTYPE_SIZES[NM_DTYPE(right)], NM_DTYPE(right)).rval;
     result_elem[k] = rb_yield_values(2, sval, tval);
     nm_unregister_value(&sval);
   }
@@ -442,7 +442,7 @@ VALUE nm_dense_map(VALUE self) {
     nm_dense_storage_coords(result, k, coords);
     size_t s_index = nm_dense_storage_pos(s, coords);
 
-    result_elem[k] = rb_yield(NM_DTYPE(self) == nm::RUBYOBJ ? reinterpret_cast<VALUE*>(s->elements)[s_index] : rubyobj_from_cval((char*)(s->elements) + s_index*DTYPE_SIZES[NM_DTYPE(self)], NM_DTYPE(self)).rval);
+    result_elem[k] = rb_yield(NM_DTYPE(self) == nm::RUBYOBJ ? reinterpret_cast<VALUE*>(s->elements)[s_index] : nm::rubyobj_from_cval((char*)(s->elements) + s_index*DTYPE_SIZES[NM_DTYPE(self)], NM_DTYPE(self)).rval);
   }
 
   VALUE klass = CLASS_OF(self);
@@ -488,7 +488,7 @@ VALUE nm_dense_each_with_indices(VALUE nmatrix) {
     VALUE ary = rb_ary_new();
     nm_register_value(&ary);
     if (NM_DTYPE(nmatrix) == nm::RUBYOBJ) rb_ary_push(ary, reinterpret_cast<VALUE*>(s->elements)[slice_index]);
-    else rb_ary_push(ary, rubyobj_from_cval((char*)(s->elements) + slice_index*DTYPE_SIZES[NM_DTYPE(nmatrix)], NM_DTYPE(nmatrix)).rval);
+    else rb_ary_push(ary, nm::rubyobj_from_cval((char*)(s->elements) + slice_index*DTYPE_SIZES[NM_DTYPE(nmatrix)], NM_DTYPE(nmatrix)).rval);
 
     for (size_t p = 0; p < s->dim; ++p) {
       rb_ary_push(ary, INT2FIX(coords[p]));
@@ -547,7 +547,7 @@ VALUE nm_dense_each(VALUE nmatrix) {
     for (size_t i = 0; i < nm_storage_count_max_elements(s); ++i) {
       nm_dense_storage_coords(sliced_dummy, i, temp_coords);
       sliced_index = nm_dense_storage_pos(s, temp_coords);
-      VALUE v = rubyobj_from_cval((char*)(s->elements) + sliced_index*DTYPE_SIZES[NM_DTYPE(nmatrix)], NM_DTYPE(nmatrix)).rval;
+      VALUE v = nm::rubyobj_from_cval((char*)(s->elements) + sliced_index*DTYPE_SIZES[NM_DTYPE(nmatrix)], NM_DTYPE(nmatrix)).rval;
       rb_yield( v ); // yield to the copy we made
     }
   }

--- a/ext/nmatrix/storage/list/list.cpp
+++ b/ext/nmatrix/storage/list/list.cpp
@@ -85,7 +85,7 @@ public:
     actual_shape_ = actual->shape;
 
     if (init_obj_ == Qnil) {
-      init_obj_ = s->dtype == nm::RUBYOBJ ? *reinterpret_cast<VALUE*>(s->default_val) : rubyobj_from_cval(s->default_val, s->dtype).rval;
+      init_obj_ = s->dtype == nm::RUBYOBJ ? *reinterpret_cast<VALUE*>(s->default_val) : nm::rubyobj_from_cval(s->default_val, s->dtype).rval;
     }
     nm_register_value(&init_obj_);
   }
@@ -193,7 +193,7 @@ static void map_empty_stored_r(RecurseData& result, RecurseData& s, LIST* x, con
     while (curr) {
       VALUE val, s_val;
       if (s.dtype() == nm::RUBYOBJ) s_val = (*reinterpret_cast<nm::RubyObject*>(curr->val)).rval;
-      else                          s_val = rubyobj_from_cval(curr->val, s.dtype()).rval;
+      else                          s_val = nm::rubyobj_from_cval(curr->val, s.dtype()).rval;
 
       if (rev) val = rb_yield_values(2, t_init, s_val);
       else     val = rb_yield_values(2, s_val, t_init);
@@ -265,7 +265,7 @@ static void map_stored_r(RecurseData& result, RecurseData& left, LIST* x, const 
       size_t key;
       VALUE  val;
 
-      val   = rb_yield_values(1, left.dtype() == nm::RUBYOBJ ? *reinterpret_cast<VALUE*>(lcurr->val) : rubyobj_from_cval(lcurr->val, left.dtype()).rval);
+      val   = rb_yield_values(1, left.dtype() == nm::RUBYOBJ ? *reinterpret_cast<VALUE*>(lcurr->val) : nm::rubyobj_from_cval(lcurr->val, left.dtype()).rval);
       key   = lcurr->key - left.offset(rec);
       lcurr = lcurr->next;
 
@@ -355,15 +355,15 @@ static void map_merged_stored_r(RecurseData& result, RecurseData& left, RecurseD
       VALUE  val;
 
       if (!rcurr || (lcurr && (lcurr->key - left.offset(rec) < rcurr->key - right.offset(rec)))) {
-        val   = rb_yield_values(2, rubyobj_from_cval(lcurr->val, left.dtype()).rval, right.init_obj());
+        val   = rb_yield_values(2, nm::rubyobj_from_cval(lcurr->val, left.dtype()).rval, right.init_obj());
         key   = lcurr->key - left.offset(rec);
         lcurr = lcurr->next;
       } else if (!lcurr || (rcurr && (rcurr->key - right.offset(rec) < lcurr->key - left.offset(rec)))) {
-	      val   = rb_yield_values(2, left.init_obj(), rubyobj_from_cval(rcurr->val, right.dtype()).rval);
+	      val   = rb_yield_values(2, left.init_obj(), nm::rubyobj_from_cval(rcurr->val, right.dtype()).rval);
         key   = rcurr->key - right.offset(rec);
         rcurr = rcurr->next;
       } else { // == and both present
-        val   = rb_yield_values(2, rubyobj_from_cval(lcurr->val, left.dtype()).rval, rubyobj_from_cval(rcurr->val, right.dtype()).rval);
+        val   = rb_yield_values(2, nm::rubyobj_from_cval(lcurr->val, left.dtype()).rval, nm::rubyobj_from_cval(rcurr->val, right.dtype()).rval);
         key   = lcurr->key - left.offset(rec);
         lcurr = lcurr->next;
         rcurr = rcurr->next;
@@ -855,7 +855,7 @@ static void each_with_indices_r(nm::list_storage::RecurseData& s, const LIST* l,
         rb_ary_unshift(stack, s.dtype() == nm::RUBYOBJ ? *reinterpret_cast<VALUE*>(s.init()) : s.init_obj());
 
       } else { // index == curr->key - offset
-        rb_ary_unshift(stack, s.dtype() == nm::RUBYOBJ ? *reinterpret_cast<VALUE*>(curr->val) : rubyobj_from_cval(curr->val, s.dtype()).rval);
+        rb_ary_unshift(stack, s.dtype() == nm::RUBYOBJ ? *reinterpret_cast<VALUE*>(curr->val) : nm::rubyobj_from_cval(curr->val, s.dtype()).rval);
 
         curr = curr->next;
       }
@@ -902,7 +902,7 @@ static void each_stored_with_indices_r(nm::list_storage::RecurseData& s, const L
       rb_ary_push(stack, LONG2NUM(static_cast<long>(curr->key - offset))); // add index to end
 
       // add value to beginning
-      rb_ary_unshift(stack, s.dtype() == nm::RUBYOBJ ? *reinterpret_cast<VALUE*>(curr->val) : rubyobj_from_cval(curr->val, s.dtype()).rval);
+      rb_ary_unshift(stack, s.dtype() == nm::RUBYOBJ ? *reinterpret_cast<VALUE*>(curr->val) : nm::rubyobj_from_cval(curr->val, s.dtype()).rval);
       // yield to the whole stack (value, i, j, k, ...)
       rb_yield_splat(stack);
 
@@ -1349,7 +1349,7 @@ STORAGE* nm_list_storage_matrix_multiply(const STORAGE_PAIR& casted_storage, siz
 VALUE nm_list_storage_to_hash(const LIST_STORAGE* s, const nm::dtype_t dtype) {
   nm_list_storage_register(s);
   // Get the default value for the list storage.
-  VALUE default_value = rubyobj_from_cval(s->default_val, dtype).rval;
+  VALUE default_value = nm::rubyobj_from_cval(s->default_val, dtype).rval;
   nm_list_storage_unregister(s);
   // Recursively copy each dimension of the matrix into a nested hash.
   return nm_list_copy_to_hash(s->rows, dtype, s->dim - 1, default_value);
@@ -1621,7 +1621,7 @@ extern "C" {
    */
   VALUE nm_list_default_value(VALUE self) {
     NM_CONSERVATIVE(nm_register_value(&self));
-    VALUE to_return = (NM_DTYPE(self) == nm::RUBYOBJ) ? *reinterpret_cast<VALUE*>(NM_DEFAULT_VAL(self)) : rubyobj_from_cval(NM_DEFAULT_VAL(self), NM_DTYPE(self)).rval;
+    VALUE to_return = (NM_DTYPE(self) == nm::RUBYOBJ) ? *reinterpret_cast<VALUE*>(NM_DEFAULT_VAL(self)) : nm::rubyobj_from_cval(NM_DEFAULT_VAL(self), NM_DTYPE(self)).rval;
     NM_CONSERVATIVE(nm_unregister_value(&self));
     return to_return;
   }

--- a/ext/nmatrix/storage/storage.cpp
+++ b/ext/nmatrix/storage/storage.cpp
@@ -289,7 +289,7 @@ LIST_STORAGE* create_from_dense_storage(const DENSE_STORAGE* rhs, dtype_t l_dtyp
 
   // need test default value for comparing to elements in dense matrix
   if (rhs->dtype == l_dtype || rhs->dtype != RUBYOBJ) *r_default_val = static_cast<RDType>(*l_default_val);
-  else                                                *r_default_val = rubyobj_from_cval(l_default_val, l_dtype);
+  else                                                *r_default_val = nm::rubyobj_from_cval(l_default_val, l_dtype);
 
 
   LIST_STORAGE* lhs = nm_list_storage_create(l_dtype, shape, rhs->dim, l_default_val);

--- a/ext/nmatrix/storage/yale/yale.cpp
+++ b/ext/nmatrix/storage/yale/yale.cpp
@@ -1336,7 +1336,7 @@ static void* default_value_ptr(const YALE_STORAGE* s) {
  */
 static VALUE obj_at(YALE_STORAGE* s, size_t k) {
   if (s->dtype == nm::RUBYOBJ)  return reinterpret_cast<VALUE*>(((YALE_STORAGE*)(s->src))->a)[k];
-  else  return rubyobj_from_cval(reinterpret_cast<void*>(reinterpret_cast<char*>(((YALE_STORAGE*)(s->src))->a) + k * DTYPE_SIZES[s->dtype]), s->dtype).rval;
+  else  return nm::rubyobj_from_cval(reinterpret_cast<void*>(reinterpret_cast<char*>(((YALE_STORAGE*)(s->src))->a) + k * DTYPE_SIZES[s->dtype]), s->dtype).rval;
 }
 
 
@@ -1345,7 +1345,7 @@ static VALUE obj_at(YALE_STORAGE* s, size_t k) {
  */
 static VALUE default_value(const YALE_STORAGE* s) {
   if (s->dtype == nm::RUBYOBJ) return *reinterpret_cast<VALUE*>(default_value_ptr(s));
-  else return rubyobj_from_cval(default_value_ptr(s), s->dtype).rval;
+  else return nm::rubyobj_from_cval(default_value_ptr(s), s->dtype).rval;
 }
 
 
@@ -1664,7 +1664,7 @@ static VALUE nm_a(int argc, VALUE* argv, VALUE self) {
       }
     } else {
       for (size_t i = 0; i < size; ++i) {
-        vals[i] = rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype]*i, s->dtype).rval;
+        vals[i] = nm::rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype]*i, s->dtype).rval;
       }
     }
     VALUE ary = rb_ary_new4(size, vals);
@@ -1681,7 +1681,7 @@ static VALUE nm_a(int argc, VALUE* argv, VALUE self) {
     NM_CONSERVATIVE(nm_unregister_value(&idx));
     NM_CONSERVATIVE(nm_unregister_value(&self));
     if (index >= size) rb_raise(rb_eRangeError, "out of range");
-    return rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype] * index, s->dtype).rval;
+    return nm::rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype] * index, s->dtype).rval;
   }
 }
 
@@ -1712,7 +1712,7 @@ static VALUE nm_d(int argc, VALUE* argv, VALUE self) {
       }
     } else {
       for (size_t i = 0; i < s->shape[0]; ++i) {
-        vals[i] = rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype]*i, s->dtype).rval;
+        vals[i] = nm::rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype]*i, s->dtype).rval;
       }
     }
     nm_unregister_values(vals, s->shape[0]);
@@ -1725,7 +1725,7 @@ static VALUE nm_d(int argc, VALUE* argv, VALUE self) {
     NM_CONSERVATIVE(nm_unregister_value(&idx));
     NM_CONSERVATIVE(nm_unregister_value(&self));
     if (index >= s->shape[0]) rb_raise(rb_eRangeError, "out of range");
-    return rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype] * index, s->dtype).rval;
+    return nm::rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype] * index, s->dtype).rval;
   }
 }
 
@@ -1752,7 +1752,7 @@ static VALUE nm_lu(VALUE self) {
     }
   } else {
     for (size_t i = 0; i < size - s->shape[0] - 1; ++i) {
-      vals[i] = rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype]*(s->shape[0] + 1 + i), s->dtype).rval;
+      vals[i] = nm::rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype]*(s->shape[0] + 1 + i), s->dtype).rval;
     }
   }
 
@@ -1927,7 +1927,7 @@ static VALUE nm_nd_row(int argc, VALUE* argv, VALUE self) {
     ret = rb_hash_new();
 
     for (size_t idx = pos; idx < nextpos; ++idx) {
-      rb_hash_aset(ret, INT2FIX(s->ija[idx]), rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype]*idx, s->dtype).rval);
+      rb_hash_aset(ret, INT2FIX(s->ija[idx]), nm::rubyobj_from_cval((char*)(s->a) + DTYPE_SIZES[s->dtype]*idx, s->dtype).rval);
     }
   }
   NM_CONSERVATIVE(nm_unregister_value(&as));

--- a/ext/nmatrix/util/sl_list.cpp
+++ b/ext/nmatrix/util/sl_list.cpp
@@ -608,7 +608,7 @@ extern "C" {
         size_t key = curr->key;
 
         if (recursions == 0) { // content is some kind of value
-          rb_hash_aset(h, INT2FIX(key), rubyobj_from_cval(curr->val, dtype).rval);
+          rb_hash_aset(h, INT2FIX(key), nm::rubyobj_from_cval(curr->val, dtype).rval);
         } else { // content is a list
           rb_hash_aset(h, INT2FIX(key), nm_list_copy_to_hash(reinterpret_cast<const LIST*>(curr->val), dtype, recursions-1, default_value));
         }

--- a/ext/nmatrix_atlas/math_atlas.cpp
+++ b/ext/nmatrix_atlas/math_atlas.cpp
@@ -270,8 +270,8 @@ static VALUE nm_atlas_cblas_rotg(VALUE self, VALUE ab) {
       rb_ary_store(result, 0, *reinterpret_cast<VALUE*>(pC));
       rb_ary_store(result, 1, *reinterpret_cast<VALUE*>(pS));
     } else {
-      rb_ary_store(result, 0, rubyobj_from_cval(pC, dtype).rval);
-      rb_ary_store(result, 1, rubyobj_from_cval(pS, dtype).rval);
+      rb_ary_store(result, 0, nm::rubyobj_from_cval(pC, dtype).rval);
+      rb_ary_store(result, 1, nm::rubyobj_from_cval(pS, dtype).rval);
     }
     NM_CONSERVATIVE(nm_unregister_value(&ab));
     NM_CONSERVATIVE(nm_unregister_value(&self));
@@ -391,7 +391,7 @@ static VALUE nm_atlas_cblas_nrm2(VALUE self, VALUE n, VALUE x, VALUE incx) {
 
     ttable[dtype](FIX2INT(n), NM_STORAGE_DENSE(x)->elements, FIX2INT(incx), Result);
 
-    return rubyobj_from_cval(Result, rdtype).rval;
+    return nm::rubyobj_from_cval(Result, rdtype).rval;
   }
 }
 
@@ -440,7 +440,7 @@ static VALUE nm_atlas_cblas_asum(VALUE self, VALUE n, VALUE x, VALUE incx) {
 
   ttable[dtype](FIX2INT(n), NM_STORAGE_DENSE(x)->elements, FIX2INT(incx), Result);
 
-  return rubyobj_from_cval(Result, rdtype).rval;
+  return nm::rubyobj_from_cval(Result, rdtype).rval;
 }
 
 /*

--- a/ext/nmatrix_lapacke/math_lapacke.cpp
+++ b/ext/nmatrix_lapacke/math_lapacke.cpp
@@ -213,8 +213,8 @@ static VALUE nm_lapacke_cblas_rotg(VALUE self, VALUE ab) {
       rb_ary_store(result, 0, *reinterpret_cast<VALUE*>(pC));
       rb_ary_store(result, 1, *reinterpret_cast<VALUE*>(pS));
     } else {
-      rb_ary_store(result, 0, rubyobj_from_cval(pC, dtype).rval);
-      rb_ary_store(result, 1, rubyobj_from_cval(pS, dtype).rval);
+      rb_ary_store(result, 0, nm::rubyobj_from_cval(pC, dtype).rval);
+      rb_ary_store(result, 1, nm::rubyobj_from_cval(pS, dtype).rval);
     }
     NM_CONSERVATIVE(nm_unregister_value(&ab));
     NM_CONSERVATIVE(nm_unregister_value(&self));
@@ -334,7 +334,7 @@ static VALUE nm_lapacke_cblas_nrm2(VALUE self, VALUE n, VALUE x, VALUE incx) {
 
     ttable[dtype](FIX2INT(n), NM_STORAGE_DENSE(x)->elements, FIX2INT(incx), Result);
 
-    return rubyobj_from_cval(Result, rdtype).rval;
+    return nm::rubyobj_from_cval(Result, rdtype).rval;
   }
 }
 
@@ -383,7 +383,7 @@ static VALUE nm_lapacke_cblas_asum(VALUE self, VALUE n, VALUE x, VALUE incx) {
 
   ttable[dtype](FIX2INT(n), NM_STORAGE_DENSE(x)->elements, FIX2INT(incx), Result);
 
-  return rubyobj_from_cval(Result, rdtype).rval;
+  return nm::rubyobj_from_cval(Result, rdtype).rval;
 }
 
 /*


### PR DESCRIPTION
I fixed some amount of codes to build nmatrix by clang of Xcode 7.1.

This pull request includes the following fixes:

- Add explicit copy constructors and operator=() in nm::Complex<Type> to fix compilation errors about implicit conversion
- Move rubyobj_from_cval into nm namespace because its return type cannot be referred from C-linkage
- Stop using variable-length array for non-POD type

I've checked this change can be built on gcc-4.6 and gcc-4.9.