### PR TITLE
support clang in FreeBSD-CURRENT

### DIFF
--- a/ext/nmatrix/data/ruby_object.h
+++ b/ext/nmatrix/data/ruby_object.h
@@ -110,7 +110,7 @@ class RubyObject {
   inline operator int16_t() const { RETURN_OBJ2NUM(NUM2INT)         }
   inline operator uint16_t() const { RETURN_OBJ2NUM(NUM2UINT)       }
   inline operator int32_t() const { RETURN_OBJ2NUM(NUM2LONG)        }
-  inline operator VALUE() const { return rval; }
+  //inline operator VALUE() const { return rval; }
   //inline operator uint32_t() const { return NUM2ULONG(this->rval);      }
   inline operator int64_t() const { RETURN_OBJ2NUM(NUM2LONG)        }
   inline operator uint64_t() const { RETURN_OBJ2NUM(NUM2ULONG)      }

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -133,6 +133,8 @@ end
 
 if CONFIG['CXX'] == 'clang++'
   $CPP_STANDARD = 'c++11'
+elsif CONFIG['CXX'] == 'c++'
+  $CPP_STANDARD = 'c++11'
 
 else
   version = gplusplus_version

--- a/ext/nmatrix_atlas/extconf.rb
+++ b/ext/nmatrix_atlas/extconf.rb
@@ -108,7 +108,7 @@ $objs = basenames.map { |b| "#{b}.o"   }
 $srcs = basenames.map { |b| "#{b}.cpp" }
 
 #CONFIG['CXX'] = 'clang++'
-CONFIG['CXX'] = 'g++'
+#CONFIG['CXX'] = 'g++'
 
 def find_newer_gplusplus #:nodoc:
   print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
@@ -137,6 +137,8 @@ end
 
 
 if CONFIG['CXX'] == 'clang++'
+  $CPP_STANDARD = 'c++11'
+elsif CONFIG['CXX'] == 'c++'
   $CPP_STANDARD = 'c++11'
 
 else

--- a/ext/nmatrix_lapacke/extconf.rb
+++ b/ext/nmatrix_lapacke/extconf.rb
@@ -108,7 +108,7 @@ $objs = basenames.map { |b| "#{b}.o"   }
 $srcs = basenames.map { |b| "#{b}.cpp" }
 
 #CONFIG['CXX'] = 'clang++'
-CONFIG['CXX'] = 'g++'
+#CONFIG['CXX'] = 'g++'
 
 def find_newer_gplusplus #:nodoc:
   print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
@@ -137,6 +137,8 @@ end
 
 
 if CONFIG['CXX'] == 'clang++'
+  $CPP_STANDARD = 'c++11'
+elif CONFIG['CXX'] == 'c++'
   $CPP_STANDARD = 'c++11'
 
 else


### PR DESCRIPTION
- comment out unused definition (this definition break the compilation).
- assume c++ as clang++ if CONFIG['CXX'] is c++.

- Note that nmatrix_atlas' compilation still fails.