### PR TITLE
Adds several specialized solver algorithms to NMatrix#solve

### DIFF
--- a/lib/nmatrix/lapacke.rb
+++ b/lib/nmatrix/lapacke.rb
@@ -214,22 +214,22 @@ class NMatrix
       ipiv = NMatrix::LAPACK.lapacke_getrf(:row, n, n, clone, n)
       NMatrix::LAPACK.lapacke_getrs(:row, :no_transpose, n, nrhs, clone, n, ipiv, x, nrhs)
       x
-    when :upper_tri
+    when :upper_tri, :upper_triangular
       raise(ArgumentError, "upper triangular solver does not work with complex dtypes") if
         complex_dtype? or b.complex_dtype?
       NMatrix::BLAS::cblas_trsm(:row, :left, :upper, false, :nounit, n, nrhs, 1.0, self, n, x, nrhs)
       x
-    when :lower_tri
+    when :lower_tri, :lower_triangular
       raise(ArgumentError, "lower triangular solver does not work with complex dtypes") if
         complex_dtype? or b.complex_dtype?
       NMatrix::BLAS::cblas_trsm(:row, :left, :lower, false, :nounit, n, nrhs, 1.0, self, n, x, nrhs)
       x
-    when :pos_def
+    when :pos_def, :positive_definite
       u, l = self.factorize_cholesky
       z = l.solve(b, form: :lower_tri)
       u.solve(z, form: :upper_tri)
     else
-      raise(ArgumentError, "#{opts[:form]} is not a valid option")
+      raise(ArgumentError, "#{opts[:form]} is not a valid form option")
     end
   end
 end

--- a/lib/nmatrix/lapacke.rb
+++ b/lib/nmatrix/lapacke.rb
@@ -195,19 +195,41 @@ class NMatrix
     NMatrix::LAPACK::lapacke_potrf(:row, which, self.shape[0], self, self.shape[1])
   end
 
-  def solve b
+  def solve(b, opts = {})
     raise(ShapeError, "Must be called on square matrix") unless self.dim == 2 && self.shape[0] == self.shape[1]
     raise(ShapeError, "number of rows of b must equal number of cols of self") if 
       self.shape[1] != b.shape[0]
-    raise ArgumentError, "only works with dense matrices" if self.stype != :dense
-    raise ArgumentError, "only works for non-integer, non-object dtypes" if 
+    raise(ArgumentError, "only works with dense matrices") if self.stype != :dense
+    raise(ArgumentError, "only works for non-integer, non-object dtypes") if 
       integer_dtype? or object_dtype? or b.integer_dtype? or b.object_dtype?
 
-    x     = b.clone
-    clone = self.clone
-    n = self.shape[0]
-    ipiv = NMatrix::LAPACK.lapacke_getrf(:row, n, n, clone, n)
-    NMatrix::LAPACK.lapacke_getrs(:row, :no_transpose, n, b.shape[1], clone, n, ipiv, x, b.shape[1])
-    x
+    opts = { form: :general }.merge(opts)
+    x    = b.clone
+    n    = self.shape[0]
+    nrhs = b.shape[1]
+
+    case opts[:form] 
+    when :general
+      clone = self.clone
+      ipiv = NMatrix::LAPACK.lapacke_getrf(:row, n, n, clone, n)
+      NMatrix::LAPACK.lapacke_getrs(:row, :no_transpose, n, nrhs, clone, n, ipiv, x, nrhs)
+      x
+    when :upper_tri
+      raise(ArgumentError, "upper triangular solver does not work with complex dtypes") if
+        complex_dtype? or b.complex_dtype?
+      NMatrix::BLAS::cblas_trsm(:row, :left, :upper, false, :nounit, n, nrhs, 1.0, self, n, x, nrhs)
+      x
+    when :lower_tri
+      raise(ArgumentError, "lower triangular solver does not work with complex dtypes") if
+        complex_dtype? or b.complex_dtype?
+      NMatrix::BLAS::cblas_trsm(:row, :left, :lower, false, :nounit, n, nrhs, 1.0, self, n, x, nrhs)
+      x
+    when :pos_def
+      u, l = self.factorize_cholesky
+      z = l.solve(b, form: :lower_tri)
+      u.solve(z, form: :upper_tri)
+    else
+      raise(ArgumentError, "#{opts[:form]} is not a valid option")
+    end
   end
 end

--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -258,36 +258,88 @@ class NMatrix
 
   # Solve the matrix equation AX = B, where A is +self+, B is the first
   # argument, and X is returned. A must be a nxn square matrix, while B must be
-  # nxm. Only works with dense
-  # matrices and non-integer, non-object data types.
+  # nxm. Only works with dense matrices and non-integer, non-object data types.
   # 
+  # == Arguments
+  #
+  # * +b+ - the right hand side
+  #
+  # == Options
+  #
+  # * +form+ - If not set then it defaults to +:general+, which uses an LU solver. 
+  #   Other possible values are +:lower_tri+, +:upper_tri+ and +:pos_def+. If +:lower_tri+
+  #   or +:upper_tri+ is set, then a specialized linear solver for linear systems AX=B
+  #   with a lower or upper triangular matrix A is used. If +:pos_def+ is chosen, then
+  #   the linear system is solved via the Cholesky factorization.
+  #   Note that when +:lower_tri+ or +:upper_tri+ is used, then the algorithm just assumes that
+  #   all entries in the lower/upper triangle of the matrix are zeros without checking (which
+  #   can be useful in certain applications).
+  #     
+  #
   # == Usage
   # 
   #   a = NMatrix.new [2,2], [3,1,1,2], dtype: dtype
   #   b = NMatrix.new [2,1], [9,8], dtype: dtype
   #   a.solve(b)
-  def solve b
+  #
+  #   # solve an upper triangular linear system more efficiently:
+  #   require 'nmatrix/lapacke'
+  #   rand_mat = NMatrix.random([10000, 10000], dtype: :float64)
+  #   a = rand_mat.triu
+  #   b = NMatrix.random([10000, 10], dtype: :float64)
+  #   Benchmark.bm(10) do |bm|
+  #     bm.report('general') { a.solve(b) }
+  #     bm.report('upper_tri') { a.solve(b, form: :upper_tri) }
+  #   end
+  #   #                   user     system      total        real
+  #   #  general     73.170000   0.670000  73.840000 ( 73.810086)
+  #   #  upper_tri    0.180000   0.000000   0.180000 (  0.182491)
+  #
+  def solve(b, opts = {})
     raise(ShapeError, "Must be called on square matrix") unless self.dim == 2 && self.shape[0] == self.shape[1]
     raise(ShapeError, "number of rows of b must equal number of cols of self") if 
       self.shape[1] != b.shape[0]
-    raise ArgumentError, "only works with dense matrices" if self.stype != :dense
-    raise ArgumentError, "only works for non-integer, non-object dtypes" if 
+    raise(ArgumentError, "only works with dense matrices") if self.stype != :dense
+    raise(ArgumentError, "only works for non-integer, non-object dtypes") if 
       integer_dtype? or object_dtype? or b.integer_dtype? or b.object_dtype?
 
-    x     = b.clone
-    clone = self.clone
-    n = self.shape[0]
+    opts = { form: :general }.merge(opts)
+    x    = b.clone
+    n    = self.shape[0]
     nrhs = b.shape[1]
 
-    ipiv = NMatrix::LAPACK.clapack_getrf(:row, n, n, clone, n)
-    # When we call clapack_getrs with :row, actually only the first matrix
-    # (i.e. clone) is interpreted as row-major, while the other matrix (x)
-    # is interpreted as column-major. See here: http://math-atlas.sourceforge.net/faq.html#RowSolve
-    # So we must transpose x before and after
-    # calling it.
-    x = x.transpose
-    NMatrix::LAPACK.clapack_getrs(:row, :no_transpose, n, nrhs, clone, n, ipiv, x, n)
-    x.transpose
+    case opts[:form] 
+    when :general
+      clone = self.clone
+      ipiv = NMatrix::LAPACK.clapack_getrf(:row, n, n, clone, n)
+      # When we call clapack_getrs with :row, actually only the first matrix
+      # (i.e. clone) is interpreted as row-major, while the other matrix (x)
+      # is interpreted as column-major. See here: http://math-atlas.sourceforge.net/faq.html#RowSolve
+      # So we must transpose x before and after
+      # calling it.
+      x = x.transpose
+      NMatrix::LAPACK.clapack_getrs(:row, :no_transpose, n, nrhs, clone, n, ipiv, x, n)
+      x.transpose
+    when :upper_tri
+      raise(ArgumentError, "upper triangular solver does not work with complex dtypes") if
+        complex_dtype? or b.complex_dtype?
+      # this is the correct function call; see https://github.com/SciRuby/nmatrix/issues/374
+      NMatrix::BLAS::cblas_trsm(:row, :left, :upper, false, :nounit, n, nrhs, 1.0, self, n, x, nrhs)
+      x
+    when :lower_tri
+      raise(ArgumentError, "lower triangular solver does not work with complex dtypes") if
+        complex_dtype? or b.complex_dtype?
+      # this is a workaround; see https://github.com/SciRuby/nmatrix/issues/422
+      x = x.transpose
+      NMatrix::BLAS::cblas_trsm(:row, :right, :lower, :transpose, :nounit, nrhs, n, 1.0, self, n, x, n)
+      x.transpose
+    when :pos_def
+      u, l = self.factorize_cholesky
+      z = l.solve(b, form: :lower_tri)
+      u.solve(z, form: :upper_tri)
+    else
+      raise(ArgumentError, "#{opts[:form]} is not a valid option")
+    end
   end
 
   #

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -553,6 +553,7 @@ describe "math" do
   context "#solve" do
     NON_INTEGER_DTYPES.each do |dtype|
       next if dtype == :object # LU factorization doesnt work for :object yet
+
       it "solves linear equation for dtype #{dtype}" do
         a = NMatrix.new [2,2], [3,1,1,2], dtype: dtype
         b = NMatrix.new [2,1], [9,8], dtype: dtype
@@ -579,6 +580,82 @@ describe "math" do
         b = NMatrix.new [3,2], [1,0, 1,2, 4,2], dtype: dtype
 
         expect(a.solve(b)).to eq(NMatrix.new [3,2], [1,0, 0,0, 2,2], dtype: dtype)
+      end
+    end
+
+    FLOAT_DTYPES.each do |dtype|
+      context "when form: :lower_tri" do
+        let(:a) { NMatrix.new([3,3], [1, 0, 0, 2, 0.5, 0, 3, 3, 9], dtype: dtype) }
+
+        it "solves a lower triangular linear system A * x = b with vector b" do
+          b = NMatrix.new([3,1], [1,2,3], dtype: dtype)
+          x = a.solve(b, form: :lower_tri)
+          r = a.dot(x) - b
+          expect(r.max).to be_within(1e-6).of(0.0)
+        end
+
+        it "solves a lower triangular linear system A * X = B with narrow B" do
+          b = NMatrix.new([3,2], [1,2,3,4,5,6], dtype: dtype)
+          x = a.solve(b, form: :lower_tri)
+          r = (a.dot(x) - b).to_flat_a
+          expect(r.max).to be_within(1e-6).of(0.0)
+        end
+
+        it "solves a lower triangular linear system A * X = B with wide B" do
+          b = NMatrix.new([3,5], (1..15).to_a, dtype: dtype)
+          x = a.solve(b, form: :lower_tri)
+          r = (a.dot(x) - b).to_flat_a
+          expect(r.max).to be_within(1e-6).of(0.0)
+        end
+      end
+
+      context "when form: :upper_tri" do
+        let(:a) { NMatrix.new([3,3], [3, 2, 1, 0, 2, 0.5, 0, 0, 9], dtype: dtype) }
+
+        it "solves an upper triangular linear system A * x = b with vector b" do
+          b = NMatrix.new([3,1], [1,2,3], dtype: dtype)
+          x = a.solve(b, form: :upper_tri)
+          r = a.dot(x) - b
+          expect(r.max).to be_within(1e-6).of(0.0)
+        end
+
+        it "solves an upper triangular linear system A * X = B with narrow B" do
+          b = NMatrix.new([3,2], [1,2,3,4,5,6], dtype: dtype)
+          x = a.solve(b, form: :upper_tri)
+          r = (a.dot(x) - b).to_flat_a
+          expect(r.max).to be_within(1e-6).of(0.0)
+        end
+
+        it "solves an upper triangular linear system A * X = B with a wide B" do
+          b = NMatrix.new([3,5], (1..15).to_a, dtype: dtype)
+          x = a.solve(b, form: :upper_tri)
+          r = (a.dot(x) - b).to_flat_a
+          expect(r.max).to be_within(1e-6).of(0.0)
+        end
+      end
+
+      context "when form: :pos_def" do
+        let(:a) { NMatrix.new([3,3], [4, 1, 2, 1, 5, 3, 2, 3, 6], dtype: dtype) }
+
+        it "solves a linear system A * X = b with positive definite A and vector b" do
+          b = NMatrix.new([3,1], [6,4,8], dtype: dtype)
+          begin
+            x = a.solve(b, form: :pos_def)
+            expect(x).to be_within(1e-6).of(NMatrix.new([3,1], [1,0,1], dtype: dtype))
+          rescue NotImplementedError
+            "Suppressing a NotImplementedError when the lapacke or atlas plugin is not available"
+          end
+        end
+      
+        it "solves a linear system A * X = B with positive definite A and matrix B" do
+          b = NMatrix.new([3,2], [8,3,14,13,14,19], dtype: dtype)
+          begin
+            x = a.solve(b, form: :pos_def)
+            expect(x).to be_within(1e-6).of(NMatrix.new([3,2], [1,-1,2,1,1,3], dtype: dtype))
+          rescue NotImplementedError
+            "Suppressing a NotImplementedError when the lapacke or atlas plugin is not available"
+          end
+        end
       end
     end
   end

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -591,20 +591,20 @@ describe "math" do
           b = NMatrix.new([3,1], [1,2,3], dtype: dtype)
           x = a.solve(b, form: :lower_tri)
           r = a.dot(x) - b
-          expect(r.max).to be_within(1e-6).of(0.0)
+          expect(r.abs.max).to be_within(1e-6).of(0.0)
         end
 
         it "solves a lower triangular linear system A * X = B with narrow B" do
           b = NMatrix.new([3,2], [1,2,3,4,5,6], dtype: dtype)
           x = a.solve(b, form: :lower_tri)
-          r = (a.dot(x) - b).to_flat_a
+          r = (a.dot(x) - b).abs.to_flat_a
           expect(r.max).to be_within(1e-6).of(0.0)
         end
 
         it "solves a lower triangular linear system A * X = B with wide B" do
           b = NMatrix.new([3,5], (1..15).to_a, dtype: dtype)
           x = a.solve(b, form: :lower_tri)
-          r = (a.dot(x) - b).to_flat_a
+          r = (a.dot(x) - b).abs.to_flat_a
           expect(r.max).to be_within(1e-6).of(0.0)
         end
       end
@@ -616,20 +616,20 @@ describe "math" do
           b = NMatrix.new([3,1], [1,2,3], dtype: dtype)
           x = a.solve(b, form: :upper_tri)
           r = a.dot(x) - b
-          expect(r.max).to be_within(1e-6).of(0.0)
+          expect(r.abs.max).to be_within(1e-6).of(0.0)
         end
 
         it "solves an upper triangular linear system A * X = B with narrow B" do
           b = NMatrix.new([3,2], [1,2,3,4,5,6], dtype: dtype)
           x = a.solve(b, form: :upper_tri)
-          r = (a.dot(x) - b).to_flat_a
+          r = (a.dot(x) - b).abs.to_flat_a
           expect(r.max).to be_within(1e-6).of(0.0)
         end
 
         it "solves an upper triangular linear system A * X = B with a wide B" do
           b = NMatrix.new([3,5], (1..15).to_a, dtype: dtype)
           x = a.solve(b, form: :upper_tri)
-          r = (a.dot(x) - b).to_flat_a
+          r = (a.dot(x) - b).abs.to_flat_a
           expect(r.max).to be_within(1e-6).of(0.0)
         end
       end


### PR DESCRIPTION
This adds an option to `NMatrix#solve` to employ specialized algorithms to solve upper or lower triangular linear systems (via `cblas_trsm`), or linear systems AX=B with a positive definite A (via Cholesky factorization). 

These algorithms seem to give a huge increase in performance even for moderately sized matrices (1000 x 1000), and a very significant improvement for bigger matrices (10000 x 10000). Here are some benchmarks ([benchmarking script](https://gist.github.com/agisga/e16143ffecb7e5b449e3)):

```
------------ Without nmatrix-lapacke -----------
(A is 1000 x 1000)
Solving an upper triangular linear system Ax = B:
                 user     system      total        real
general      0.240000   0.000000   0.240000 (  0.243816)
upper_tri    0.000000   0.010000   0.010000 (  0.004677)
Solving a lower triangular linear system Ax = B:
                 user     system      total        real
general      0.250000   0.000000   0.250000 (  0.243189)
lower_tri    0.000000   0.000000   0.000000 (  0.007118)
------------ With nmatrix-lapacke -----------
(A is 10000 x 10000)
Solving an upper triangular linear system Ax = B:
                 user     system      total        real
general     72.690000   0.740000  73.430000 ( 73.364571)
upper_tri    0.170000   0.000000   0.170000 (  0.172651)
Solving a lower triangular linear system Ax = B:
                 user     system      total        real
general     74.070000   0.620000  74.690000 ( 74.615631)
lower_tri    0.180000   0.000000   0.180000 (  0.176675)
Solving a linear system Ax = B with positive definite A:
                 user     system      total        real
general     72.560000   0.790000  73.350000 ( 73.278503)
pos_def      0.170000   0.000000   0.170000 (  0.168285)
```

The specialized algorithms can be employed by using the new option `form`, which denotes the form of the matrix A, and has possible values `:general` (the default), `:lower_tri`, `:upper_tri`, and `:pos_def`.

I thought about putting this algorithms as separate methods, but I think it makes sense to have all of them together in `NMatrix#solve`, especially since other specialized solvers can be added in the same way (such as Hessenberg, symmetric, etc.). But please let me know if you think it would be better to define separate methods (like `#triangular_solve`, `#pos_def_solve`, etc.).