### PR TITLE
Improve Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,30 @@
 language: ruby
 sudo: required
 cache: bundler
+os:
+  - linux
+  - osx
+osx_image: xcode7.2
 env:
-  - USE_ATLAS=1 # This configuration installs ATLAS, builds and tests the nmatrix, nmatrix-atlas, and nmatrix-lapacke gems
+  - USE_ATLAS=1       # This configuration installs ATLAS, builds and tests the nmatrix, nmatrix-atlas, and nmatrix-lapacke gems
+  - USE_OPENBLAS=1    # Installs OpenBLAS and reference LAPACK, builds and tests nmatrix, nmatrix-lapacke
+  - USE_REF=1         # Installs OpenBLAS and reference LAPACK, builds and tests nmatrix, nmatrix-lapacke
+  - NO_EXTERNAL_LIB=1 # No external libraries installed, only nmatrix
 rvm:
   - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
+  - 2.0.0-p648
+  - 2.1.8
+  - 2.2.4
   - 2.3.0
   - ruby-head
+  # The latest stable and head versions built by clang
+  - 2.3.0-clang
+  - ruby-head-clang
+
 before_install: ./travis.sh before_install
+
+install: ./travis.sh install
+
 script: ./travis.sh script
 
 # Define extra configurations to add to the build matrix.
@@ -18,21 +32,78 @@ script: ./travis.sh script
 # code, so it is the only one we need to test with all versions of ruby.
 # For other configurations we only test with one version of ruby.
 matrix:
+  exclude:
+    # NOTE: The following two ruby versions on OSX are currently unavailable
+    - os: osx
+      rvm: 2.0.0-p648
+    - os: osx
+      rvm: 2.1.8
+    - os: osx
+      rvm: 2.2.4
+    - os: osx
+      rvm: 2.3.0
+    - os: osx
+      rvm: ruby-head
+    - os: osx
+      rvm: 2.3.0-clang
+    - os: osx
+      rvm: ruby-head-clang
+    # FIXME: The following configuration is unavailable because ATLAS should be built from source.
+    #        We need homebrew formula for ATLAS and its bottle.
+    - os: osx
+      env: USE_ATLAS=1
+    # FIXME: The following configuration takes too long time when installing homebrew/dupes/lapack.
+    #        We need the bottle of lapack formula.
+    - os: osx
+      env: USE_REF=1
   include:
-    #For some reason this OpenBLAS configuration isn't working on travis, disable it for now.
-    #- rvm: 2.2
-    #  env: USE_OPENBLAS=1 # Installs OpenBLAS and reference LAPACK, builds and tests nmatrix, nmatrix-lapacke
-    - rvm: 2.2
-      env: USE_REF=1 # Installs reference implementations of LAPACK and BLAS, builds and tests nmatrix, nmatrix-lapacke
-    - rvm: 2.2
-      env: NO_EXTERNAL_LIB=1 # No external libraries installed, only nmatrix
-    - rvm: 2.3.0
-      env: USE_REF=1 # Installs reference implementations of LAPACK and BLAS, builds and tests nmatrix, nmatrix-lapacke
-    - rvm: 2.3.0
-      env: NO_EXTERNAL_LIB=1 # No external libraries installed, only nmatrix
-    - rvm: ruby-head
-      env: USE_REF=1 # Installs reference implementations of LAPACK and BLAS, builds and tests nmatrix, nmatrix-lapacke
-    - rvm: ruby-head
-      env: NO_EXTERNAL_LIB=1 # No external libraries installed, only nmatrix
+    # The latest stable and head versions of ruby built by clang on OSX
+    - os: osx
+      compiler: clang
+      rvm: 2.2
+      env:
+        - ruby_version=2.4.0-dev USE_OPENBLAS=1
+    - os: osx
+      compiler: clang
+      rvm: 2.2
+      env:
+        - ruby_version=2.4.0-dev NO_EXTERNAL_LIB=1
+    - os: osx
+      compiler: clang
+      rvm: 2.2
+      env:
+        - ruby_version=2.3.0 USE_OPENBLAS=1
+    - os: osx
+      compiler: clang
+      rvm: 2.2
+      env:
+        - ruby_version=2.3.0 NO_EXTERNAL_LIB=1
+    # The latest version of Ruby 2.2.x built by clang on OSX
+    - os: osx
+      compiler: clang
+      rvm: 2.2
+      env:
+        - ruby_version=2.2.4 USE_OPENBLAS=1
+    # The latest version of Ruby 2.1.x built by clang on OSX
+    - os: osx
+      compiler: clang
+      rvm: 2.2
+      env:
+        - ruby_version=2.1.8 USE_OPENBLAS=1
+  allow_failures:
+    # Ruby versions which got EOL
+    - rvm: 1.9.3
+    # trunk
+    - env: ruby_version=2.4.0-dev USE_OPENBLAS=1
+    - env: ruby_version=2.4.0-dev NO_EXTERNAL_LIB=1
+    # linux with clang
+    - os: linux
+      rvm: 2.3.0-clang
+    - os: linux
+      rvm: ruby-head-clang
+    # For some reason this OpenBLAS configuration isn't working on travis, disable it for now.
+    - os: linux
+      env: USE_OPENBLAS=1
+
 notifications:
   irc: "chat.freenode.net#sciruby"

--- a/Rakefile
+++ b/Rakefile
@@ -271,4 +271,28 @@ RDoc::Task.new do |rdoc|
   rdoc.options << "--exclude=lib/nmatrix/rspec.rb"
 end
 
+namespace :travis do
+  task :env do
+    puts "\n# Build environment:"
+    %w[
+      CC CXX
+      USE_ATLAS USE_OPENBLAS USE_REF NO_EXTERNAL_LIB
+      TRAVIS_OS_NAME TRAVIS_BRANCH TRAVIS_COMMIT TRAVIS_PULL_REQUEST
+    ].each do |name|
+      puts "- #{name}: #{ENV[name]}"
+    end
+
+    require 'rbconfig'
+    puts "\n# RbConfig::MAKEFILE_CONFIG values:"
+    %w[
+      CC CXX CPPFLAGS CFLAGS CXXFLAGS
+    ].each do |name|
+      puts "- #{name}: #{RbConfig::MAKEFILE_CONFIG[name]}"
+    end
+
+    cc = RbConfig::MAKEFILE_CONFIG['CC']
+    puts "\n$ #{cc} -v\n#{`#{cc} -v 2>&1`}"
+  end
+end
+
 # vim: syntax=ruby

--- a/ext/nmatrix/data/complex.h
+++ b/ext/nmatrix/data/complex.h
@@ -32,6 +32,7 @@
  * Standard Includes
  */
 
+#include <ruby.h>
 #include <type_traits>
 #include <iostream>
 #include <cmath>

--- a/ext/nmatrix/data/data.h
+++ b/ext/nmatrix/data/data.h
@@ -31,6 +31,8 @@
 /*
  * Standard Includes
  */
+
+#include <ruby.h>
 #include <string>
 
 /*

--- a/ext/nmatrix/data/ruby_object.h
+++ b/ext/nmatrix/data/ruby_object.h
@@ -59,7 +59,7 @@ template<typename T, typename U>
 struct made_from_same_template : std::false_type {}; 
  
 template<template<typename> class Templ, typename Arg1, typename Arg2>
-struct made_from_same_template<Templ<Arg1>, Templ<Arg2>> : std::true_type {};
+struct made_from_same_template<Templ<Arg1>, Templ<Arg2> > : std::true_type {};
 
 class RubyObject {
   public:

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -132,7 +132,7 @@ end
 
 
 if CONFIG['CXX'] == 'clang++'
-  $CPP_STANDARD = 'c++11'
+  $CXX_STANDARD = 'c++11'
 
 else
   version = gplusplus_version
@@ -144,11 +144,11 @@ else
   end
 
   if version < '4.7.0'
-    $CPP_STANDARD = 'c++0x'
+    $CXX_STANDARD = 'c++0x'
   else
-    $CPP_STANDARD = 'c++11'
+    $CXX_STANDARD = 'c++11'
   end
-  puts "using C++ standard... #{$CPP_STANDARD}"
+  puts "using C++ standard... #{$CXX_STANDARD}"
   puts "g++ reports version... " + `#{CONFIG['CXX']} --version|head -n 1|cut -f 3 -d " "`
 end
 
@@ -157,8 +157,8 @@ end
 # For release, these next two should both be changed to -O3.
 $CFLAGS += " -O3 "
 #$CFLAGS += " -static -O0 -g "
-$CPPFLAGS += " -O3 -std=#{$CPP_STANDARD} " #-fmax-errors=10 -save-temps
-#$CPPFLAGS += " -static -O0 -g -std=#{$CPP_STANDARD} "
+$CXXFLAGS += " -O3 -std=#{$CXX_STANDARD} " #-fmax-errors=10 -save-temps
+#$CXXFLAGS += " -static -O0 -g -std=#{$CXX_STANDARD} "
 
 CONFIG['warnflags'].gsub!('-Wshorten-64-to-32', '') # doesn't work except in Mac-patched gcc (4.2)
 CONFIG['warnflags'].gsub!('-Wdeclaration-after-statement', '')

--- a/ext/nmatrix/math.cpp
+++ b/ext/nmatrix/math.cpp
@@ -126,6 +126,7 @@
  */
 
 
+#include <ruby.h>
 #include <algorithm>
 #include <limits>
 #include <cmath>

--- a/ext/nmatrix/storage/common.h
+++ b/ext/nmatrix/storage/common.h
@@ -32,6 +32,7 @@
  * Standard Includes
  */
 
+#include <ruby.h>
 #include <cmath> // pow().
 
 /*

--- a/ext/nmatrix/storage/dense/dense.h
+++ b/ext/nmatrix/storage/dense/dense.h
@@ -32,7 +32,8 @@
  * Standard Includes
  */
 
-#include <stdlib.h>
+#include <ruby.h>
+#include <cstdlib>
 
 /*
  * Project Includes

--- a/ext/nmatrix/storage/list/list.h
+++ b/ext/nmatrix/storage/list/list.h
@@ -33,7 +33,8 @@
  * Standard Includes
  */
 
-#include <stdlib.h>
+#include <ruby.h>
+#include <cstdlib>
 #include <list>
 /*
  * Project Includes

--- a/ext/nmatrix/storage/storage.h
+++ b/ext/nmatrix/storage/storage.h
@@ -34,6 +34,7 @@
  * Standard Includes
  */
 
+#include <ruby.h>
 #include <cstdlib>
 
 /*

--- a/ext/nmatrix/storage/yale/iterators/base.h
+++ b/ext/nmatrix/storage/yale/iterators/base.h
@@ -29,6 +29,7 @@
 #ifndef YALE_ITERATORS_BASE_H
 # define YALE_ITERATORS_BASE_H
 
+#include <ruby.h>
 #include <type_traits>
 #include <typeinfo>
 #include <stdexcept>

--- a/ext/nmatrix/storage/yale/iterators/iterator.h
+++ b/ext/nmatrix/storage/yale/iterators/iterator.h
@@ -29,6 +29,7 @@
 #ifndef YALE_ITERATORS_ITERATOR_H
 # define YALE_ITERATORS_ITERATOR_H
 
+#include <ruby.h>
 #include <type_traits>
 #include <typeinfo>
 

--- a/ext/nmatrix/storage/yale/iterators/row.h
+++ b/ext/nmatrix/storage/yale/iterators/row.h
@@ -31,6 +31,7 @@
 #ifndef YALE_ITERATORS_ROW_H
 # define YALE_ITERATORS_ROW_H
 
+#include <ruby.h>
 #include <stdexcept>
 
 namespace nm { namespace yale_storage {

--- a/ext/nmatrix/storage/yale/iterators/row_stored.h
+++ b/ext/nmatrix/storage/yale/iterators/row_stored.h
@@ -34,6 +34,7 @@
 #ifndef YALE_ITERATORS_ROW_STORED_H
 # define YALE_ITERATORS_ROW_STORED_H
 
+#include <ruby.h>
 #include <stdexcept>
 
 namespace nm { namespace yale_storage {

--- a/ext/nmatrix/storage/yale/iterators/row_stored_nd.h
+++ b/ext/nmatrix/storage/yale/iterators/row_stored_nd.h
@@ -29,6 +29,7 @@
 #ifndef YALE_ITERATORS_ROW_STORED_ND_H
 # define YALE_ITERATORS_ROW_STORED_ND_H
 
+#include <ruby.h>
 #include <type_traits>
 #include <typeinfo>
 #include <stdexcept>

--- a/ext/nmatrix/storage/yale/iterators/stored_diagonal.h
+++ b/ext/nmatrix/storage/yale/iterators/stored_diagonal.h
@@ -29,6 +29,7 @@
 #ifndef YALE_ITERATORS_STORED_DIAGONAL_H
 # define YALE_ITERATORS_STORED_DIAGONAL_H
 
+#include <ruby.h>
 #include <type_traits>
 #include <typeinfo>
 

--- a/ext/nmatrix/storage/yale/yale.h
+++ b/ext/nmatrix/storage/yale/yale.h
@@ -42,6 +42,7 @@
  * Standard Includes
  */
 
+#include <ruby.h>
 #include <limits> // for std::numeric_limits<T>::max()
 #include <stdexcept>
 

--- a/ext/nmatrix/types.h
+++ b/ext/nmatrix/types.h
@@ -32,6 +32,7 @@
  * Standard Includes
  */
 
+#include <ruby.h>
 #include <cstdint>
 
 /*

--- a/ext/nmatrix/util/sl_list.h
+++ b/ext/nmatrix/util/sl_list.h
@@ -33,6 +33,7 @@
  * Standard Includes
  */
 
+#include <ruby.h>
 #include <type_traits>
 #include <cstdlib>
 

--- a/ext/nmatrix_atlas/extconf.rb
+++ b/ext/nmatrix_atlas/extconf.rb
@@ -107,9 +107,6 @@ basenames = %w{nmatrix_atlas math_atlas}
 $objs = basenames.map { |b| "#{b}.o"   }
 $srcs = basenames.map { |b| "#{b}.cpp" }
 
-#CONFIG['CXX'] = 'clang++'
-CONFIG['CXX'] = 'g++'
-
 def find_newer_gplusplus #:nodoc:
   print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
   [9,8,7,6,5,4,3].each do |minor|
@@ -137,7 +134,7 @@ end
 
 
 if CONFIG['CXX'] == 'clang++'
-  $CPP_STANDARD = 'c++11'
+  $CXX_STANDARD = 'c++11'
 
 else
   version = gplusplus_version
@@ -149,11 +146,11 @@ else
   end
 
   if version < '4.7.0'
-    $CPP_STANDARD = 'c++0x'
+    $CXX_STANDARD = 'c++0x'
   else
-    $CPP_STANDARD = 'c++11'
+    $CXX_STANDARD = 'c++11'
   end
-  puts "using C++ standard... #{$CPP_STANDARD}"
+  puts "using C++ standard... #{$CXX_STANDARD}"
   puts "g++ reports version... " + `#{CONFIG['CXX']} --version|head -n 1|cut -f 3 -d " "`
 end
 
@@ -233,8 +230,8 @@ $libs += " -llapack -lcblas -latlas "
 # For release, these next two should both be changed to -O3.
 $CFLAGS += " -O3" #" -O0 -g "
 #$CFLAGS += " -static -O0 -g "
-$CPPFLAGS += " -O3 -std=#{$CPP_STANDARD}" #" -O0 -g -std=#{$CPP_STANDARD} " #-fmax-errors=10 -save-temps
-#$CPPFLAGS += " -static -O0 -g -std=#{$CPP_STANDARD} "
+$CXXFLAGS += " -O3 -std=#{$CXX_STANDARD}" #" -O0 -g -std=#{$CXX_STANDARD} " #-fmax-errors=10 -save-temps
+#$CPPFLAGS += " -static -O0 -g -std=#{$CXX_STANDARD} "
 
 CONFIG['warnflags'].gsub!('-Wshorten-64-to-32', '') # doesn't work except in Mac-patched gcc (4.2)
 CONFIG['warnflags'].gsub!('-Wdeclaration-after-statement', '')

--- a/ext/nmatrix_lapacke/extconf.rb
+++ b/ext/nmatrix_lapacke/extconf.rb
@@ -107,9 +107,6 @@ basenames = %w{nmatrix_lapacke math_lapacke lapacke}
 $objs = basenames.map { |b| "#{b}.o"   }
 $srcs = basenames.map { |b| "#{b}.cpp" }
 
-#CONFIG['CXX'] = 'clang++'
-CONFIG['CXX'] = 'g++'
-
 def find_newer_gplusplus #:nodoc:
   print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
   [9,8,7,6,5,4,3].each do |minor|
@@ -137,7 +134,7 @@ end
 
 
 if CONFIG['CXX'] == 'clang++'
-  $CPP_STANDARD = 'c++11'
+  $CXX_STANDARD = 'c++11'
 
 else
   version = gplusplus_version
@@ -149,11 +146,11 @@ else
   end
 
   if version < '4.7.0'
-    $CPP_STANDARD = 'c++0x'
+    $CXX_STANDARD = 'c++0x'
   else
-    $CPP_STANDARD = 'c++11'
+    $CXX_STANDARD = 'c++11'
   end
-  puts "using C++ standard... #{$CPP_STANDARD}"
+  puts "using C++ standard... #{$CXX_STANDARD}"
   puts "g++ reports version... " + `#{CONFIG['CXX']} --version|head -n 1|cut -f 3 -d " "`
 end
 
@@ -187,8 +184,8 @@ $libs += " -llapack "
 # For release, these next two should both be changed to -O3.
 $CFLAGS += " -O3" #" -O0 -g "
 #$CFLAGS += " -static -O0 -g "
-$CPPFLAGS += " -O3 -std=#{$CPP_STANDARD}" #" -O0 -g -std=#{$CPP_STANDARD} " #-fmax-errors=10 -save-temps
-#$CPPFLAGS += " -static -O0 -g -std=#{$CPP_STANDARD} "
+$CXXFLAGS += " -O3 -std=#{$CXX_STANDARD}" #" -O0 -g -std=#{$CXX_STANDARD} " #-fmax-errors=10 -save-temps
+#$CPPFLAGS += " -static -O0 -g -std=#{$CXX_STANDARD} "
 
 CONFIG['warnflags'].gsub!('-Wshorten-64-to-32', '') # doesn't work except in Mac-patched gcc (4.2)
 CONFIG['warnflags'].gsub!('-Wdeclaration-after-statement', '')

--- a/travis.sh
+++ b/travis.sh
@@ -2,14 +2,64 @@
 
 set -ev #fail at the first command that returns non-zero exit value
 
+# Use rbenv on OSX iff ruby_version is given
+if [ -n "$ruby_version" -a "$TRAVIS_OS_NAME" = "osx" ]; then
+  export PATH="$HOME/.rbenv/bin:$PATH"
+  if [ -x $HOME/.rbenv/bin/rbenv ]; then
+    eval "$(rbenv init -)"
+  fi
+  export RBENV_VERSION=$ruby_version
+fi
+
+if [ "$1" = "install" ]
+then
+  bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+fi
+
 if [ "$1" = "before_install" ]
 then
+  case "$TRAVIS_OS_NAME" in
+    linux)
+      sudo apt-get update -qq
+      ;;
+    osx)
+      brew update >/dev/null
+      ;;
+  esac
+
+  # Installing ruby by using rbenv on OSX iff ruby_version is given
+  if [ -n "$ruby_version" -a "$TRAVIS_OS_NAME" = "osx" ]; then
+    git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+    git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
+
+    eval "$(rbenv init -)"
+
+    # Install ruby
+    (
+      brew install bison openssl readline libyaml
+      brew link --force openssl
+      RBENV_VERSION=system
+      MAKEOPTS='-j 4'
+      CONFIGURE_OPTS="--disable-install-doc --with-out-ext=tk,tk/tkutil --with-opt-dir=/usr/local"
+      rbenv install $ruby_version
+    )
+    gem update --system
+    gem update
+  fi
+
   gem install bundler -v '~> 1.6'
-  sudo apt-get update -qq
 
   if [ -n "$USE_ATLAS" ]
   then
-    sudo apt-get install -y libatlas-base-dev
+    case "$TRAVIS_OS_NAME" in
+      linux)
+        sudo apt-get install -y libatlas-base-dev
+        ;;
+      osx)
+        echo "FIXME: ATLAS on OSX environment is not supported, currently" >2
+        exit 1
+        ;;
+    esac
   fi
 
   # travis-ci runs on Ubuntu 12.04, where the openblas package doesn't
@@ -18,43 +68,64 @@ then
   # this will work.
   if [ -n "$USE_OPENBLAS" ]
   then
-    sudo apt-get install -y libopenblas-dev
-    # Since we install libopenblas first, liblapack won't try to install
-    # libblas (the reference BLAS implementation).
-    sudo apt-get install -y liblapack-dev
+    case "$TRAVIS_OS_NAME" in
+      linux)
+        sudo apt-get install -y libopenblas-dev
+        # Since we install libopenblas first, liblapack won't try to install
+        # libblas (the reference BLAS implementation).
+        sudo apt-get install -y liblapack-dev
+        ;;
+      osx)
+        brew install homebrew/science/openblas
+        ;;
+    esac
   fi
 
   if [ -n "$USE_REF" ]
   then
-    sudo apt-get install -y liblapack-dev
+    case "$TRAVIS_OS_NAME" in
+      linux)
+        sudo apt-get install -y liblapack-dev
+        ;;
+      osx)
+        brew install homebrew/dupes/lapack
+        ;;
+    esac
   fi
 fi
 
 if [ "$1" = "script" ]
 then
+  nmatrix_plugins_opt=''
+
   if [ -n "$USE_ATLAS" ]
   then
     # Need to put these commands on separate lines (rather than use &&)
     # so that bash set -e will work.
-    bundle exec rake compile nmatrix_plugins=all
-    bundle exec rake spec nmatrix_plugins=all
+    nmatrix_plugins_opt='nmatrix_plugins=all'
   fi
 
   if [ -n "$USE_OPENBLAS" ]
   then
-    bundle exec rake compile nmatrix_plugins=lapacke
-    bundle exec rake spec nmatrix_plugins=lapacke
+    nmatrix_plugins_opt='nmatrix_plugins=lapacke'
   fi
 
   if [ -n "$USE_REF" ]
   then
-    bundle exec rake compile nmatrix_plugins=lapacke
-    bundle exec rake spec nmatrix_plugins=lapacke
+    nmatrix_plugins_opt='nmatrix_plugins=lapacke'
   fi
 
   if [ -n "$NO_EXTERNAL_LIB" ]
   then
-    bundle exec rake compile
-    bundle exec rake spec
+    nmatrix_plugins_opt=''
   fi
+
+  bundle exec rake travis:env
+
+  bundle exec rake compile $nmatrix_plugins_opt || {
+    echo === Contents of mkmf.log ===
+    cat tmp/*/nmatrix/*/mkmf.log
+    exit 1
+  }
+  bundle exec rake spec $nmatrix_plugins_opt
 fi


### PR DESCRIPTION
I'd like to improve the configuration of Travis CI in this pull request.

The following changes are made:
- Adding 2.3.0 and ruby-head
- Adding ruby versions built with clang
- Adding OSX configuration
- Use rbenv for 2.3.0 and ruby-head on OSX
- Dump some environment variables before starting script
- Use exclusion for unavailable configurations instead of commented them out
- Specify allow_failures for unstable configurations

They makes it more easy to track nmatrix stability on both linux and osx.

Currently configurations for ruby-2.3.0 and ruby-head on OSX are failed.
But I will fix them asap.

I think this PR resolves #392 and #399.