### PR TITLE
Replace RARRAY_PTR with RARRAY_AREF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3.0
+  - ruby-head
 before_install: ./travis.sh before_install
 script: ./travis.sh script
 
@@ -23,6 +25,14 @@ matrix:
     - rvm: 2.2
       env: USE_REF=1 # Installs reference implementations of LAPACK and BLAS, builds and tests nmatrix, nmatrix-lapacke
     - rvm: 2.2
+      env: NO_EXTERNAL_LIB=1 # No external libraries installed, only nmatrix
+    - rvm: 2.3.0
+      env: USE_REF=1 # Installs reference implementations of LAPACK and BLAS, builds and tests nmatrix, nmatrix-lapacke
+    - rvm: 2.3.0
+      env: NO_EXTERNAL_LIB=1 # No external libraries installed, only nmatrix
+    - rvm: ruby-head
+      env: USE_REF=1 # Installs reference implementations of LAPACK and BLAS, builds and tests nmatrix, nmatrix-lapacke
+    - rvm: ruby-head
       env: NO_EXTERNAL_LIB=1 # No external libraries installed, only nmatrix
 notifications:
   irc: "chat.freenode.net#sciruby"

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -164,6 +164,11 @@ CONFIG['warnflags'].gsub!('-Wshorten-64-to-32', '') # doesn't work except in Mac
 CONFIG['warnflags'].gsub!('-Wdeclaration-after-statement', '')
 CONFIG['warnflags'].gsub!('-Wimplicit-function-declaration', '')
 
+have_func("rb_array_const_ptr", "ruby.h")
+have_macro("FIX_CONST_VALUE_PTR", "ruby.h")
+have_macro("RARRAY_CONST_PTR", "ruby.h")
+have_macro("RARRAY_AREF", "ruby.h")
+
 create_conf_h("nmatrix_config.h")
 create_makefile("nmatrix")
 

--- a/ext/nmatrix/math.cpp
+++ b/ext/nmatrix/math.cpp
@@ -1002,7 +1002,7 @@ static VALUE nm_clapack_getrs(VALUE self, VALUE order, VALUE trans, VALUE n, VAL
   } else {
     ipiv_ = NM_ALLOCA_N(int, RARRAY_LEN(ipiv));
     for (int index = 0; index < RARRAY_LEN(ipiv); ++index) {
-      ipiv_[index] = FIX2INT( RARRAY_PTR(ipiv)[index] );
+      ipiv_[index] = FIX2INT( RARRAY_AREF(ipiv, index) );
     }
   }
 
@@ -1054,7 +1054,7 @@ static VALUE nm_clapack_laswp(VALUE self, VALUE n, VALUE a, VALUE lda, VALUE k1,
   } else {
     ipiv_ = NM_ALLOCA_N(int, RARRAY_LEN(ipiv));
     for (int index = 0; index < RARRAY_LEN(ipiv); ++index) {
-      ipiv_[index] = FIX2INT( RARRAY_PTR(ipiv)[index] );
+      ipiv_[index] = FIX2INT( RARRAY_AREF(ipiv, index) );
     }
   }
 

--- a/ext/nmatrix/nmatrix.h
+++ b/ext/nmatrix/nmatrix.h
@@ -57,6 +57,33 @@
   #include "nm_memory.h"
 #endif
 
+#ifndef FIX_CONST_VALUE_PTR
+# if defined(__fcc__) || defined(__fcc_version) || \
+    defined(__FCC__) || defined(__FCC_VERSION)
+/* workaround for old version of Fujitsu C Compiler (fcc) */
+#  define FIX_CONST_VALUE_PTR(x) ((const VALUE *)(x))
+# else
+#  define FIX_CONST_VALUE_PTR(x) (x)
+# endif
+#endif
+
+#ifndef HAVE_RB_ARRAY_CONST_PTR
+static inline const VALUE *
+rb_array_const_ptr(VALUE a)
+{
+  return FIX_CONST_VALUE_PTR((RBASIC(a)->flags & RARRAY_EMBED_FLAG) ?
+    RARRAY(a)->as.ary : RARRAY(a)->as.heap.ptr);
+}
+#endif
+
+#ifndef RARRAY_CONST_PTR
+# define RARRAY_CONST_PTR(a) rb_array_const_ptr(a)
+#endif
+
+#ifndef RARRAY_AREF
+# define RARRAY_AREF(a, i) (RARRAY_CONST_PTR(a)[i])
+#endif
+
 /*
  * Macros
  */

--- a/ext/nmatrix/ruby_nmatrix.c
+++ b/ext/nmatrix/ruby_nmatrix.c
@@ -2636,7 +2636,7 @@ nm::dtype_t nm_dtype_guess(VALUE v) {
      * TODO: Look at entire array for most specific type.
      */
 
-    return nm_dtype_guess(RARRAY_PTR(v)[0]);
+    return nm_dtype_guess(RARRAY_AREF(v, 0));
 
   default:
     RB_P(v);
@@ -2798,7 +2798,7 @@ static void* interpret_initial_value(VALUE arg, nm::dtype_t dtype) {
     init_val = NM_ALLOC_N(char, DTYPE_SIZES[dtype] * RARRAY_LEN(arg));
     NM_CHECK_ALLOC(init_val);
     for (index = 0; index < RARRAY_LEN(arg); ++index) {
-      rubyval_to_cval(RARRAY_PTR(arg)[index], dtype, (char*)init_val + (index * DTYPE_SIZES[dtype]));
+      rubyval_to_cval(RARRAY_AREF(arg, index), dtype, (char*)init_val + (index * DTYPE_SIZES[dtype]));
     }
 
   } else {
@@ -2825,7 +2825,7 @@ static size_t* interpret_shape(VALUE arg, size_t* dim) {
     shape = NM_ALLOC_N(size_t, *dim);
 
     for (size_t index = 0; index < *dim; ++index) {
-      shape[index] = FIX2UINT( RARRAY_PTR(arg)[index] );
+      shape[index] = FIX2UINT( RARRAY_AREF(arg, index) );
     }
 
   } else if (FIXNUM_P(arg)) {

--- a/ext/nmatrix_atlas/extconf.rb
+++ b/ext/nmatrix_atlas/extconf.rb
@@ -240,6 +240,11 @@ CONFIG['warnflags'].gsub!('-Wshorten-64-to-32', '') # doesn't work except in Mac
 CONFIG['warnflags'].gsub!('-Wdeclaration-after-statement', '')
 CONFIG['warnflags'].gsub!('-Wimplicit-function-declaration', '')
 
+have_func("rb_array_const_ptr", "ruby.h")
+have_macro("FIX_CONST_VALUE_PTR", "ruby.h")
+have_macro("RARRAY_CONST_PTR", "ruby.h")
+have_macro("RARRAY_AREF", "ruby.h")
+
 create_conf_h("nmatrix_atlas_config.h")
 create_makefile("nmatrix_atlas")
 

--- a/ext/nmatrix_atlas/math_atlas.cpp
+++ b/ext/nmatrix_atlas/math_atlas.cpp
@@ -1019,7 +1019,7 @@ static VALUE nm_atlas_clapack_getrs(VALUE self, VALUE order, VALUE trans, VALUE 
   } else {
     ipiv_ = NM_ALLOCA_N(int, RARRAY_LEN(ipiv));
     for (int index = 0; index < RARRAY_LEN(ipiv); ++index) {
-      ipiv_[index] = FIX2INT( RARRAY_PTR(ipiv)[index] );
+      ipiv_[index] = FIX2INT( RARRAY_AREF(ipiv, index) );
     }
   }
 
@@ -1104,7 +1104,7 @@ static VALUE nm_atlas_clapack_getri(VALUE self, VALUE order, VALUE n, VALUE a, V
   } else {
     ipiv_ = NM_ALLOCA_N(int, RARRAY_LEN(ipiv));
     for (int index = 0; index < RARRAY_LEN(ipiv); ++index) {
-      ipiv_[index] = FIX2INT( RARRAY_PTR(ipiv)[index] );
+      ipiv_[index] = FIX2INT( RARRAY_AREF(ipiv, index) );
     }
   }
 
@@ -1191,7 +1191,7 @@ static VALUE nm_atlas_clapack_laswp(VALUE self, VALUE n, VALUE a, VALUE lda, VAL
   } else {
     ipiv_ = NM_ALLOCA_N(int, RARRAY_LEN(ipiv));
     for (int index = 0; index < RARRAY_LEN(ipiv); ++index) {
-      ipiv_[index] = FIX2INT( RARRAY_PTR(ipiv)[index] );
+      ipiv_[index] = FIX2INT( RARRAY_AREF(ipiv, index) );
     }
   }
 

--- a/ext/nmatrix_lapacke/extconf.rb
+++ b/ext/nmatrix_lapacke/extconf.rb
@@ -194,6 +194,11 @@ CONFIG['warnflags'].gsub!('-Wshorten-64-to-32', '') # doesn't work except in Mac
 CONFIG['warnflags'].gsub!('-Wdeclaration-after-statement', '')
 CONFIG['warnflags'].gsub!('-Wimplicit-function-declaration', '')
 
+have_func("rb_array_const_ptr", "ruby.h")
+have_macro("FIX_CONST_VALUE_PTR", "ruby.h")
+have_macro("RARRAY_CONST_PTR", "ruby.h")
+have_macro("RARRAY_AREF", "ruby.h")
+
 create_conf_h("nmatrix_lapacke_config.h")
 create_makefile("nmatrix_lapacke")
 

--- a/ext/nmatrix_lapacke/math_lapacke.cpp
+++ b/ext/nmatrix_lapacke/math_lapacke.cpp
@@ -652,7 +652,7 @@ static VALUE nm_lapacke_lapacke_getri(VALUE self, VALUE order, VALUE n, VALUE a,
   } else {
     ipiv_ = NM_ALLOCA_N(int, RARRAY_LEN(ipiv));
     for (int index = 0; index < RARRAY_LEN(ipiv); ++index) {
-      ipiv_[index] = FIX2INT( RARRAY_PTR(ipiv)[index] );
+      ipiv_[index] = FIX2INT( RARRAY_AREF(ipiv, index) );
     }
   }
 
@@ -744,7 +744,7 @@ static VALUE nm_lapacke_lapacke_getrs(VALUE self, VALUE order, VALUE trans, VALU
   } else {
     ipiv_ = NM_ALLOCA_N(int, RARRAY_LEN(ipiv));
     for (int index = 0; index < RARRAY_LEN(ipiv); ++index) {
-      ipiv_[index] = FIX2INT( RARRAY_PTR(ipiv)[index] );
+      ipiv_[index] = FIX2INT( RARRAY_AREF(ipiv, index) );
     }
   }
 


### PR DESCRIPTION
Introducing RARRAY_AREF and related macros and functions.
This macro introduced from ruby 2.3.0 is the correct way to refer elements from an array.

This is more better direction to resolve #429 than #432, I think.

@v0dro Please check it.