### PR TITLE
[WIP] Adds hilbert matrix and inverse hilbert matrix as per #441

### DIFF
--- a/lib/nmatrix/shortcuts.rb
+++ b/lib/nmatrix/shortcuts.rb
@@ -236,6 +236,86 @@ class NMatrix
       m
     end
     alias :identity :eye
+
+    #
+    # call-seq:
+    #     hilbert(shape) -> NMatrix
+    #     hilbert(shape, dtype: dtype) -> NMatrix
+    #     hilbert(shape, stype: stype, dtype: dtype) -> NMatrix
+    #
+    # Creates an hilbert matrix (square matrix).
+    #
+    # * *Arguments* :
+    #   - +size+ -> integer ( for square matrix) specifying the dimensions.
+    #   - +dtype+ -> (optional) Default is +:float64+
+    #   - +stype+ -> (optional) Default is +:dense+.
+    # * *Returns* :
+    #   - A hilbert matrix.
+    #
+    # Examples:
+    #
+    #    NMatrix.hilbert(3) # =>  1.0     0.5      0.3333333333333333
+    #            0.5                         0.3333333333333333    0.25
+    #            0.3333333333333333          0.25                  0.2
+    #
+    def hilbert(shape, opts={})
+      m = NMatrix.new([shape,shape], {:dtype => :float64}.merge(opts))
+      0.upto(shape - 1) do |i|
+        0.upto(i) do |j|
+          m[i,j] = 1.0 / (j + i + 1)
+          m[j,i] = m[i,j] if i != j
+        end
+      end
+      m
+    end
+
+    #
+    # call-seq:
+    #     inv_hilbert(shape) -> NMatrix
+    #     inv_hilbert(shape, dtype: dtype) -> NMatrix
+    #     inv_hilbert(shape, stype: stype, dtype: dtype) -> NMatrix
+    #
+    # Creates an inverse hilbert matrix (square matrix rank 2).
+    #
+    # * *Arguments* :
+    #   - +size+ -> Array (or integer for square matrix) specifying the dimensions.
+    #   - +dtype+ -> (optional) Default is +:float64+
+    #   - +stype+ -> (optional) Default is +:dense+.
+    # * *Returns* :
+    #   - A hilbert matrix.
+    #
+    # Examples:
+    #    NMatrix.inv_hilbert(3) # =>   9.0,  -36.0,   30.0
+    #                          -36.0,  192.0, -180.0
+    #                          30.0, -180.0,  180.0
+    #
+    #
+    def inv_hilbert(shape, opts={})
+      opts = {:dtype => :float64}.merge(opts)
+      m = NMatrix.new([shape,shape],opts)
+      combination = NMatrix.new([2*shape,2*shape],opts)
+      #combinations refers to the combination of n things taken k at a time
+      0.upto(2*shape-1) do |i|
+        0.upto(i) do |j|
+          if j != 0 and j != i
+            combination[i,j] = combination[i-1,j] + combination[i-1,j-1]
+          else
+            combination[i,j] = 1
+          end
+        end
+      end
+
+      0.upto(shape-1) do |i|
+        0.upto(i) do |j|
+          m[i,j] = combination[shape + j,shape - i - 1] * ((i+j)+1) * \
+          combination[shape + i,shape - j - 1] * (-1) ** ((i+j)) * \
+          combination[(i+j),i] * combination[(i+j),i]
+          m[j,i] = m[i,j] if i != j
+        end
+      end
+      m
+    end
+
     #
     # call-seq:
     #     diagonals(array) -> NMatrix

--- a/spec/shortcuts_spec.rb
+++ b/spec/shortcuts_spec.rb
@@ -50,6 +50,41 @@ describe NMatrix do
     expect(m).to eq identity3
   end
 
+  it "hilbert() creates an hilbert matrix" do
+    m = NMatrix.hilbert(8)
+    expect(m[4, 0]).to be_within(0.000001).of(0.2)
+    expect(m[4, 1]).to be_within(0.000001).of(0.16666666666666666)
+    expect(m[4, 2]).to be_within(0.000001).of(0.14285714285714285)
+    expect(m[4, 3]).to be_within(0.000001).of(0.125)
+
+    m = NMatrix.hilbert(3)
+    hilbert3 = NMatrix.new([3, 3], [1.0, 0.5, 0.3333333333333333,\
+     0.5, 0.3333333333333333, 0.25, 0.3333333333333333, 0.25, 0.2])
+    expect(m).to eq hilbert3
+    0.upto(2) do |i|
+      0.upto(2) do |j|
+        expect(m[i, j]).to be_within(0.000001).of(hilbert3[i,j])
+      end
+    end
+  end
+
+  it "inv_hilbert() creates an inverse hilbert matrix" do
+    m = NMatrix.inv_hilbert(6)
+    inv_hilbert6 = [3360.0,  -88200.0,   564480.0, -1411200.0]
+    expect(m[2,0]).to be_within(0.000001).of(inv_hilbert6[0])
+    expect(m[2,1]).to be_within(0.000001).of(inv_hilbert6[1])
+    expect(m[2,2]).to be_within(0.000001).of(inv_hilbert6[2])
+    expect(m[2,3]).to be_within(0.000001).of(inv_hilbert6[3])
+
+    m = NMatrix.inv_hilbert(3)
+    inv_hilbert3 = NMatrix.new([3, 3], [  9.0,  -36.0,   30.0, -36.0,  192.0, -180.0, 30.0, -180.0,  180.0] )
+    0.upto(2) do |i|
+      0.upto(2) do |j|
+        expect(m[i, j]).to be_within(0.000001).of(inv_hilbert3[i,j])
+      end
+    end
+  end
+
   it "diag() creates a matrix with pre-supplied diagonal" do
     arr = [1,2,3,4]
     m = NMatrix.diag(arr)


### PR DESCRIPTION
Adds hilbert matrix and inverse hilbert matrix
Both the functions work in O(n*n) for an n x n matrix(square matrix).

## Hilbert Matrix
`H[i,j]=1/(i+j-1)`
This takes O(n^2) time as this function is applied to every entry of the matrix.

## Inverse Hilbert Matrix
One of the fastest ways to calculate inverse matrix uses the formula given on [Wikipedia.](https://en.wikipedia.org/wiki/Hilbert_matrix)
This also involves binomial coefficients which can be calculated via dynamic programming in 
O(n^2).
Note: Inverse hilbert matrix has only _integer entries_ as proved [here.](http://math.stackexchange.com/questions/430060/why-does-the-inverse-of-the-hilbert-matrix-have-integer-entries) 


Example
```
[3] pry(main)> NMatrix.hilbert(4)
=> 
[
  [               1.0,                0.5,  0.3333333333333333,                0.25]
  [               0.5, 0.3333333333333333,                0.25,                 0.2]
  [0.3333333333333333,               0.25,                 0.2, 0.16666666666666666]
  [              0.25,                0.2, 0.16666666666666666, 0.14285714285714285]
]
[4] pry(main)> NMatrix.inv_hilbert(4)
=> 
[
  [  16.0,  -120.0,   240.0,  -140.0]
  [-120.0,  1200.0, -2700.0,  1680.0]
  [ 240.0, -2700.0,  6480.0, -4200.0]
  [-140.0,  1680.0, -4200.0,  2800.0]

```




 