### PR TITLE
Fix NMatrix#reshape!

### DIFF
--- a/ext/nmatrix/ruby_nmatrix.c
+++ b/ext/nmatrix/ruby_nmatrix.c
@@ -1106,6 +1106,9 @@ static VALUE nm_reshape_bang(VALUE self, VALUE arg){
     if (size == new_size){
       s->shape = shape;
       s->dim = dim;
+      NM_FREE(s->offset);
+      s->offset = NM_ALLOC_N(size_t, dim);
+      memset(s->offset, 0, sizeof(size_t)*dim);
       size_t i, j;
       size_t* stride = NM_ALLOC_N(size_t, dim);
       for (i = 0; i < dim; ++i) {
@@ -1113,8 +1116,9 @@ static VALUE nm_reshape_bang(VALUE self, VALUE arg){
         for (j = i+1; j < dim; ++j) {
           stride[i] *= shape[j];
         }
-        s->stride = stride;
       }
+      NM_FREE(s->stride);
+      s->stride = stride;
       return self;
      }
      else

--- a/spec/00_nmatrix_spec.rb
+++ b/spec/00_nmatrix_spec.rb
@@ -424,6 +424,13 @@ describe 'NMatrix' do
       expect(n.reshape!([8,2]).eql?(n)).to eq(true) # because n itself changes
     end
 
+    it "should do the reshape operation in place, changing dimension" do
+      n = NMatrix.seq(4)
+      a = n.reshape!([4,2,2])
+      expect(n).to eq(NMatrix.seq([4,2,2]))
+      expect(a).to eq(NMatrix.seq([4,2,2]))
+    end
+
     it "reshape and reshape! must produce same result" do
       n = NMatrix.seq(4)+1
       a = NMatrix.seq(4)+1
@@ -432,7 +439,7 @@ describe 'NMatrix' do
 
     it "should prevent a resize in place" do
       n = NMatrix.seq(4)+1
-      expect { n.reshape([5,2]) }.to raise_error(ArgumentError)
+      expect { n.reshape!([5,2]) }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
This fixes #449. The problem was that the offset array wasn't getting resized when the dimension changed, so the offset values were uninitialized.