### PR TITLE
Issue #453 : Add NMatrix#linspace()

### DIFF
--- a/lib/nmatrix/shortcuts.rb
+++ b/lib/nmatrix/shortcuts.rb
@@ -468,6 +468,58 @@ class NMatrix
 
     #
     # call-seq:
+    #     linspace(base, limit) -> 1x100 NMatrix
+    #     linspace(base, limit, *shape) -> NMatrix
+    #
+    # Returns an NMatrix with +[shape[0] x shape[1] x .. x shape[dim-1]]+ values of dtype +:float64+ equally spaced from
+    # +base+ to +limit+, inclusive.
+    #
+    # See: http://www.mathworks.com/help/matlab/ref/linspace.html
+    #
+    # * *Arguments* :
+    #   - +base+ -> The first value in the sequence.
+    #   - +limit+ -> The last value in the sequence.
+    #   - +shape+ -> Desired output shape. Default returns a 1x100 row vector.
+    # * *Returns* :
+    #   - NMatrix with +:float64+ values.
+    #
+    # Examples :-
+    #
+    #   NMatrix.linspace(1,Math::PI, 6)
+    #     =>[1.0,
+    #        1.4283185005187988,
+    #        1.8566370010375977,
+    #        2.2849555015563965,
+    #        2.7132740020751953,
+    #        3.1415927410125732
+    #       ]
+    #
+    #   NMatrix.linspace(1,10, [3,2])
+    #     =>[
+    #         [              1.0, 2.799999952316284]
+    #         [4.599999904632568, 6.400000095367432]
+    #         [8.199999809265137,              10.0]
+    #       ]
+    #
+    def linspace(base, limit, shape = [100])
+      
+      # Convert shape to array format 
+      shape = [shape] if shape.is_a? Integer 
+      
+      #Calculate number of elements 
+      count = shape.inject(:*)
+            
+      # Linear spacing between elements calculated in step
+      #   step = limit - base / (count - 1)
+      #   [Result Sequence] = [0->N sequence] * step + [Base]
+      step = (limit - base) * (1.0 / (count - 1))
+      result = NMatrix.seq(shape, {:dtype => :float64}) * step
+      result += NMatrix.new(shape, base)
+      result
+    end
+
+    #
+    # call-seq:
     #     seq(shape) -> NMatrix
     #     seq(shape, options) -> NMatrix
     #     bindgen(shape) -> NMatrix of :byte

--- a/spec/shortcuts_spec.rb
+++ b/spec/shortcuts_spec.rb
@@ -158,6 +158,33 @@ describe NMatrix do
       expect { NMatrix.random("not an array or integer") }.to raise_error
     end
   end
+  
+  context "::linspace" do
+    it "creates a row vector when given only one shape parameter" do
+      v = NMatrix.linspace(1, 10, 4)
+      #Expect a row vector only
+      expect(v.shape.length).to eq(1)
+      
+      ans = [1.0,4.0,7.0,10.0]
+
+      expect(v[0]).to be_within(0.000001).of(ans[0])
+      expect(v[1]).to be_within(0.000001).of(ans[1])
+      expect(v[2]).to be_within(0.000001).of(ans[2])
+      expect(v[3]).to be_within(0.000001).of(ans[3])
+    end
+    
+    it "creates a matrix of input shape with each entry linearly spaced in row major order" do
+      v = NMatrix.linspace(1, Math::PI, [2,2])
+      expect(v.dtype).to eq(:float64)
+
+      ans = [1.0, 1.7138642072677612, 2.4277284145355225, 3.1415927410125732]
+      
+      expect(v[0,0]).to be_within(0.000001).of(ans[0])
+      expect(v[0,1]).to be_within(0.000001).of(ans[1])
+      expect(v[1,0]).to be_within(0.000001).of(ans[2])
+      expect(v[1,1]).to be_within(0.000001).of(ans[3])
+    end
+  end
 
   it "seq() creates a matrix of integers, sequentially" do
     m = NMatrix.seq(2) # 2x2 matrix.
@@ -170,7 +197,6 @@ describe NMatrix do
       end
     end
   end
-
 
   it "indgen() creates a matrix of integers as well as seq()" do
     m = NMatrix.indgen(2) # 2x2 matrix.


### PR DESCRIPTION
 Added `linspace()` function described in issue #453. 

I am a bit unsure about whether  `shape = [100]`  should be interpreted as a row vector or a square matrix? As of this implementation, square matrices need to have their shape defined in both dimensions while shape = N or shape = [N] will return a row vector. 
