### PR TITLE
Issue #459 : Add NMatrix#logspace

### DIFF
--- a/lib/nmatrix/shortcuts.rb
+++ b/lib/nmatrix/shortcuts.rb
@@ -518,6 +518,54 @@ class NMatrix
       result
     end
 
+    # call-seq:
+    #     logspace(base, limit) -> 1x50 NMatrix with exponent_base = 10 
+    #     logspace(base, limit, shape , exponent_base:) -> NMatrix
+    #     logspace(base, :pi, n) -> 1xn NMatrix with interval [10 ^ base, Math::PI]
+    #
+    # Returns an NMatrix with +[shape[0] x shape[1] x .. x shape[dim-1]]+ values of dtype +:float64+ logarithmically spaced from
+    # +exponent_base ^ base+ to +exponent_base ^ limit+, inclusive.
+    #
+    # See: http://www.mathworks.com/help/matlab/ref/logspace.html
+    #
+    # * *Arguments* :
+    #   - +base+ -> exponent_base ** base is the first value in the sequence
+    #   - +limit+ -> exponent_base ** limit is the last value in the sequence.
+    #   - +shape+ -> Desired output shape. Default returns a 1x50 row vector.
+    # * *Returns* :
+    #   - NMatrix with +:float64+ values.
+    #
+    # Examples :-
+    #
+    #   NMatrix.logspace(1,:pi,7)
+    #     =>[
+    #         10.0000, 
+    #         8.2450, 
+    #         6.7980, 
+    #         5.6050, 
+    #         4.6213, 
+    #         3.8103, 
+    #         3.1416
+    #       ]
+    #
+    #   NMatrix.logspace(1,2,[3,2])
+    #     =>[
+    #         [10.0, 15.8489]
+    #         [25.1189, 39.8107]
+    #         [63.0957, 100.0]
+    #       ]
+    #
+    def logspace(base, limit, shape = [50], exponent_base: 10)
+
+      #Calculate limit for [10 ^ base ... Math::PI] if limit = :pi
+      limit = Math.log(Math::PI, exponent_base = 10) if limit == :pi 
+      shape = [shape] if shape.is_a? Integer
+
+      #[base...limit]  -> [exponent_base ** base ... exponent_base ** limit]
+      result = NMatrix.linspace(base, limit, shape)
+      result.map {|element| exponent_base ** element}
+    end
+
     #
     # call-seq:
     #     seq(shape) -> NMatrix

--- a/spec/shortcuts_spec.rb
+++ b/spec/shortcuts_spec.rb
@@ -186,6 +186,56 @@ describe NMatrix do
     end
   end
 
+  context "::logspace" do
+    it "creates a logarithmically spaced vector" do
+      v = NMatrix.logspace(1, 2, 10)
+      
+      expect(v.shape.length).to eq(1)
+      
+      #Unit test taken from Matlab R2015b output of logspace(1,2,10)
+      ans = [10.0000, 12.9155, 16.6810, 21.5443, 27.8256, 35.9381, 46.4159, 59.9484, 77.4264, 100.0000]
+      
+      expect(v[0].round(4)).to be_within(0.000001).of(ans[0])
+      expect(v[1].round(4)).to be_within(0.000001).of(ans[1])
+      expect(v[2].round(4)).to be_within(0.000001).of(ans[2])
+      expect(v[3].round(4)).to be_within(0.000001).of(ans[3])
+      expect(v[4].round(4)).to be_within(0.000001).of(ans[4])
+      expect(v[5].round(4)).to be_within(0.000001).of(ans[5])
+      expect(v[6].round(4)).to be_within(0.000001).of(ans[6])
+      expect(v[7].round(4)).to be_within(0.000001).of(ans[7])
+      expect(v[8].round(4)).to be_within(0.000001).of(ans[8])
+      expect(v[9].round(4)).to be_within(0.000001).of(ans[9])
+    end
+    
+    it "creates a logarithmically spaced vector bounded by Math::PI if :pi is pre-supplied" do
+      v = NMatrix.logspace(1, :pi, 7)
+                 
+      #Unit test taken from Matlab R2015b output of logspace(1,pi,10)
+      ans = [10.0000, 8.2450, 6.7980, 5.6050, 4.6213, 3.8103, 3.1416]
+      
+      expect(v[0].round(4)).to be_within(0.000001).of(ans[0])
+      expect(v[1].round(4)).to be_within(0.000001).of(ans[1])
+      expect(v[2].round(4)).to be_within(0.000001).of(ans[2])
+      expect(v[3].round(4)).to be_within(0.000001).of(ans[3])
+      expect(v[4].round(4)).to be_within(0.000001).of(ans[4])
+      expect(v[5].round(4)).to be_within(0.000001).of(ans[5])
+      expect(v[6].round(4)).to be_within(0.000001).of(ans[6])
+    end    
+
+    it "creates a matrix of input shape with each entry logarithmically spaced in row major order" do
+      v = NMatrix.logspace(1, 2, [3,2])
+      
+      ans = [10.0, 15.8489, 25.1189, 39.8107, 63.0957, 100.0]
+      
+      expect(v[0,0].round(4)).to be_within(0.000001).of(ans[0])
+      expect(v[0,1].round(4)).to be_within(0.000001).of(ans[1])
+      expect(v[1,0].round(4)).to be_within(0.000001).of(ans[2])
+      expect(v[1,1].round(4)).to be_within(0.000001).of(ans[3])
+      expect(v[2,0].round(4)).to be_within(0.000001).of(ans[4])
+      expect(v[2,1].round(4)).to be_within(0.000001).of(ans[5])
+    end
+  end
+
   it "seq() creates a matrix of integers, sequentially" do
     m = NMatrix.seq(2) # 2x2 matrix.
     value = 0


### PR DESCRIPTION
Implemented the logspace() function described in Issue #459. I'm not too sure how to iterate through a general shaped matrix so I've raised an exception if it's anything larger than a 2D matrix. 