### PR TITLE
#positive_definite, #positive_semidefinite, #full_rank?, #get_rank, #…

### DIFF
--- a/ext/nmatrix/nmatrix.cpp
+++ b/ext/nmatrix/nmatrix.cpp
@@ -32,6 +32,7 @@
  */
 
 #include <ruby.h>
+#include <float.h>
 #include <algorithm> // std::min
 #include <fstream>
 

--- a/ext/nmatrix/ruby_nmatrix.c
+++ b/ext/nmatrix/ruby_nmatrix.c
@@ -364,6 +364,12 @@ void Init_nmatrix() {
   rb_define_alias(cNMatrix, "effective_dim", "effective_dimensions");
   rb_define_alias(cNMatrix, "equal?", "eql?");
 
+  //////////////
+  // Epsilons //
+  //////////////
+  rb_define_const(cNMatrix, "FLOAT64_EPSILON", rb_const_get(rb_cFloat, rb_intern("EPSILON")));
+  rb_define_const(cNMatrix, "FLOAT32_EPSILON", DBL2NUM(FLT_EPSILON));
+
   ///////////////////////
   // Symbol Generation //
   ///////////////////////

--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -623,6 +623,31 @@ class NMatrix
     product
   end
 
+  def get_rank(workspace_size=1)
+    sigmas = self.gesvd[1].to_a.flatten
+    eps = NMatrix::FLOAT64_EPSILON
+
+    # epsilon depends on the width of the number
+    if (self.dtype == :float32 || self.dtype == :complex64) 
+    eps = NMatrix::FLOAT32_EPSILON
+    end
+
+    tol = self.shape.max * sigmas.max * eps
+
+    sigmas.map { |x| x > tol ? 1 : 0 }.reduce(:+)
+  end
+
+  def full_rank?
+    # if it's a square matrix, save some computation time
+    # and just check if determinant is > 0
+    return self.det != 0 if self.shape[0] == self.shape[1]
+    self.get_rank == self.shape.min
+  end
+
+  def rank_deficient?
+    !full_rank?
+  end
+
   # Compute the Kronecker product of +self+ and other NMatrix
   #
   # === Arguments

--- a/spec/00_nmatrix_spec.rb
+++ b/spec/00_nmatrix_spec.rb
@@ -740,4 +740,85 @@ describe 'NMatrix' do
       expect(NMatrix.meshgrid([@x, @y, @z], sparse: true, indexing: :ij)).to eq(@expected_3dim_sparse_ij)
     end
   end
+
+# positive definite
+  context "#positive_definite?" do
+    it "returns false for a non-square matrix" do 
+      n = NMatrix.random([3,4])
+      expect(n.positive_definite?).to eq(false)
+    end
+
+    it "returns false for a negative 1x1 matrix" do
+      n = NMatrix.new([1,1], [-1])
+      expect(n.positive_definite?).to eq(false)
+    end
+
+    it "returns true for a positive 1x1 matrix" do
+      n = NMatrix.new([1,1], [1])
+      expect(n.positive_definite?).to eq(true)
+    end
+
+    it "returns false for a square matrix with negative diagonal value" do
+      n = NMatrix.new([2,2], [0, 1, 2, -3])
+      expect(n.positive_definite?).to eq(false)
+    end
+
+    it "returns false for a 2x2 matrix with a negative determinant of submatrix" do
+      n = NMatrix.new([2,2], [1, 10, 20, 2])
+      expect(n.positive_definite?).to eq(false)
+    end
+
+    it "returns false for a 3x3 matrix with a negative determinant of submatrix" do
+      n = NMatrix.new([3,3], [1,10,4,20,2,5,8,7,6])
+      expect(n.positive_definite?).to eq(false)
+    end
+
+    it "returns false for a 3x3 matrix with all zero values" do
+      n = NMatrix.zeros([3,3])
+      expect(n.positive_definite?).to eq(false)
+    end
+
+    it "returns true for a 2x2 matrix with positive submatrix determinants" do
+      n = NMatrix.new([2,2], [20, 1, 10, 2])
+      expect(n.positive_definite?).to eq(true)
+    end
+
+    it "returns true for a 3x3 identity matrix" do
+      n = NMatrix.eye(3)
+      expect(n.positive_definite?).to eq(true)
+    end
+
+    it "returns true for a 3x3 matrix with positive submatrix determinants" do
+      n = NMatrix.new([3,3], [2,-1,-1,-1,2,1,-1,1,2])
+      expect(n.positive_definite?).to eq(true)
+    end
+
+    it "returns false for a 3x3 matrix with one nonpositive (0) submatrix determinant" do
+      n = NMatrix.new([3,3], [2,-1,-1,-1,2,-1,-1,-1,2])
+      expect(n.positive_definite?).to eq(false)
+    end
+
+    it "returns false for a 3x3 matrix with one negative submatrix determinant" do
+      n = NMatrix.new([3,3], [1,2,3,2,5,4,3,4,9])
+      expect(n.positive_definite?).to eq(false)
+    end
+
+    it "returns true for a 4x4 matrix with positive submatrix determinants" do
+      n = NMatrix.new([4,4], [1,2,0,0, 2,6,-2, 0, 0, -2,5,-2,0,0,-2,3])
+      expect(n.positive_definite?).to eq(true)
+    end
+  end
+
+  context "#positive_semidefinite?" do
+    # positive semidefinite
+    it "returns true for a 3x3 matrix with one nonpositive (0) submatrix determinant" do
+      n = NMatrix.new([3,3], [2,-1,-1,-1,2,-1,-1,-1,2])
+      expect(n.positive_semidefinite?).to eq(true)
+    end
+
+    it "returns false for a 3x3 negative definite matrix" do
+      n = NMatrix.new([3,3], [-10,1,10,1,1,-10,19,20,1])
+      expect(n.positive_semidefinite?).to eq(false)
+    end
+  end
 end

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -609,6 +609,83 @@ describe "math" do
         end
       end
 
+      [:float32, :float64, :complex64, :complex128].each do |dtype|
+        context dtype do
+          # full rank
+          it "returns full rank for identity matrix" do
+            n = NMatrix.new([3,3], [1,0,0,0,1,0,0,0,1], :dtype => dtype)
+
+            begin 
+              expect(n.full_rank?).to be(true)
+            rescue NotImplementedError => e
+              pending e.to_s
+            end
+          end
+
+          it "returns full rank for a full rank square matrix" do
+            n = NMatrix.new([3,3], [81,51,89, 30, 2, 86, 92, 89, 60], :dtype => dtype)
+
+            begin 
+              expect(n.full_rank?).to be(true)
+            rescue NotImplementedError => e
+              pending e.to_s
+            end
+          end
+
+          it "returns full rank for a full rank rectangular matrix" do
+            n = NMatrix.new([4,3], [1,2,3, 81,51,89, 30, 2, 86, 92, 89, 60], :dtype => dtype)
+
+            begin 
+              expect(n.full_rank?).to be(true)
+            rescue NotImplementedError => e
+              pending e.to_s
+            end
+          end
+
+          # rank deficient
+          it "returns rank deficient for a non-full rank matrix" do
+            n = NMatrix.new([3,3], [1,2,3,3,6,9,6,12,18], :dtype => dtype)
+
+            begin 
+              expect(n.rank_deficient?).to be(true)
+            rescue NotImplementedError => e
+              pending e.to_s
+            end
+          end
+
+          # get rank of a matrix
+          it "returns rank 3 for a matrix of rank 3" do
+            n = NMatrix.new([3,3], [81,51,89, 30, 2, 86, 92, 89, 60], :dtype => dtype)
+
+            begin 
+              expect(n.get_rank).to be(3)
+            rescue NotImplementedError => e
+              pending e.to_s
+            end
+          end
+
+          it "returns rank 2 for a matrix with 2 independent rows" do
+            n = NMatrix.new([3,3], [1,2,3,3,6,9, 92, 89, 60], :dtype => dtype)
+
+            begin 
+              expect(n.get_rank).to be(2)
+            rescue NotImplementedError => e
+              pending e.to_s
+            end
+          end
+
+          it "returns rank 1 for a matrix with a matrix with linearly dependent rows" do
+            n = NMatrix.new([3,3], [1,2,3,3,6,9,6,12,18], :dtype => dtype)
+
+            begin 
+              expect(n.get_rank).to be(1)
+            rescue NotImplementedError => e
+              pending e.to_s
+            end
+          end
+        end
+      end
+
       context "when form: :upper_tri" do
         let(:a) { NMatrix.new([3,3], [3, 2, 1, 0, 2, 0.5, 0, 0, 9], dtype: dtype) }
 


### PR DESCRIPTION
…rank_deficient?
Handles https://github.com/SciRuby/nmatrix/issues/411, along with a method to get the rank of a matrix.  

Added a couple of constants to define 32 bit and 64 bit epsilon.
For the definite check, if the matrix is semi-large it will take forever - I'm currently working on an implementation using GCT (https://www.quora.com/What-does-Gershgorins-Disk-theorem-say-intuitively).

Regarding the failing tests, it appears that the last merge had six failing tests - the ones I added pass.

Sorry for the 2 other PR's, hopefully this one does the trick!
