### PR TITLE
Fixing divide by zero bug in cblas_nrm2

### DIFF
--- a/ext/nmatrix/math/nrm2.h
+++ b/ext/nmatrix/math/nrm2.h
@@ -89,7 +89,8 @@ ReturnDType nrm2(const int N, const DType* X, const int incX) {
       temp  = scale / absxi;
       scale = absxi;
       ssq   = ONE + ssq * (temp * temp);
-    } else {
+    }
+    else if(scale != 0) {
       temp = absxi / scale;
       ssq += temp * temp;
     }
@@ -106,7 +107,8 @@ static inline void nrm2_complex_helper(const FloatDType& xr, const FloatDType& x
     double temp  = scale / absx;
     scale = absx;
     ssq   = 1.0 + ssq * (temp * temp);
-  } else {
+  }
+  else if(scale != 0)  {
     double temp = absx / scale;
     ssq += temp * temp;
   }
@@ -116,7 +118,8 @@ static inline void nrm2_complex_helper(const FloatDType& xr, const FloatDType& x
     double temp  = scale / absx;
     scale = absx;
     ssq   = 1.0 + ssq * (temp * temp);
-  } else {
+  }
+  else if(scale != 0)  {
     double temp = absx / scale;
     ssq += temp * temp;
   }

--- a/spec/blas_spec.rb
+++ b/spec/blas_spec.rb
@@ -189,9 +189,11 @@ describe NMatrix::BLAS do
 
         if dtype =~ /complex/
           x = NMatrix.new([3,1], [Complex(1,2),Complex(3,4),Complex(0,6)], dtype: dtype)
+          y = NMatrix.new([3,1], [Complex(0,0),Complex(0,0),Complex(0,0)], dtype: dtype)
           nrm2 = 8.12403840463596
         else
           x = NMatrix.new([4,1], [2,-4,3,5], dtype: dtype)
+          y = NMatrix.new([3,1], [0,0,0], dtype: dtype)
           nrm2 = 5.385164807134504
         end
         
@@ -205,6 +207,7 @@ describe NMatrix::BLAS do
               end
 
         expect(NMatrix::BLAS.nrm2(x, 1, 3)).to be_within(err).of(nrm2)
+        expect(NMatrix::BLAS.nrm2(y, 1, 3)).to be_within(err).of(0)
       end
 
     end


### PR DESCRIPTION
The norm function give wrong answer when the initial element is zero as division by zero occurs.
For example
```
[1] pry(main)> x=N[0.0,1]
=> [0.0, 1.0]
[2] pry(main)> x.nrm2
=> NaN
[3] pry(main)> x=N[1.0,0]
=> [1.0, 0.0]
[4] pry(main)> x.nrm2
=> 1.0
```
We can see the different output because of zero first element. 


