### PR TITLE
Add #scale and #scale! methods by exposing BLAS scal

### DIFF
--- a/lib/nmatrix/blas.rb
+++ b/lib/nmatrix/blas.rb
@@ -287,7 +287,23 @@ module NMatrix::BLAS
       ::NMatrix::BLAS.cblas_nrm2(n, x, incx)
     end
 
-    # new scal
+    #
+    # call-seq:
+    #     scal(alpha, vector, incx, n)
+    #
+    # Calculate the 2-norm of a vector +x+ of size +n+
+    #
+    # * *Arguments* :
+    #   - +alpha+ -> a scaling factor
+    #   - +vector+ -> an NMatrix
+    #   - +incx+ -> the skip size (defaults to 1)
+    #   - +n+ -> the size of +x+ (defaults to +x.size / incx+)
+    # * *Returns* :
+    #   - The scaling result
+    # * *Raises* :
+    #   - +ArgumentError+ -> Expected dense NMatrix for arg 0
+    #   - +RangeError+ -> n out of range
+    #
     def scal(alpha, vector, incx=1, n=nil)
       n ||= vector.size / incx
       raise(ArgumentError, "Expected dense NMatrix for arg 0") unless vector.is_a?(NMatrix)

--- a/lib/nmatrix/blas.rb
+++ b/lib/nmatrix/blas.rb
@@ -287,6 +287,14 @@ module NMatrix::BLAS
       ::NMatrix::BLAS.cblas_nrm2(n, x, incx)
     end
 
+    # new scal
+    def scal(alpha, vector, incx=1, n=nil)
+      n ||= vector.size / incx
+      raise(ArgumentError, "Expected dense NMatrix for arg 0") unless vector.is_a?(NMatrix)
+      raise(RangeError, "n out of range") if n*incx > vector.size || n*incx <= 0 || n <= 0
+      ::NMatrix::BLAS.cblas_scal(n, alpha, vector, incx)
+    end
+
     # The following are functions that used to be implemented in C, but
     # now require nmatrix-atlas or nmatrix-lapcke to run properly, so we can just
     # implemented their stubs in Ruby.

--- a/lib/nmatrix/blas.rb
+++ b/lib/nmatrix/blas.rb
@@ -291,7 +291,7 @@ module NMatrix::BLAS
     # call-seq:
     #     scal(alpha, vector, incx, n)
     #
-    # Calculate the 2-norm of a vector +x+ of size +n+
+    # Scale a matrix by a given scaling factor
     #
     # * *Arguments* :
     #   - +alpha+ -> a scaling factor

--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -893,11 +893,11 @@ class NMatrix
   # Return the scaling result of the matrix. BLAS scal will be invoked if provided.
 
   def scale!(alpha, incx=1, n=nil)
-    raise(TypeError, "Invalid type of the scaling argument") unless
+    raise(DataTypeError, "Incompatible data type for the scaling factor") unless
         NMatrix::upcast(self.dtype, NMatrix::min_dtype(alpha)) == self.dtype
     return NMatrix::BLAS::scal(alpha, self, incx, self.size / incx) if NMatrix::BLAS.method_defined? :scal
-    self.each_stored_with_indices do |e, i|
-      self[i] = e*alpha
+    self.each_stored_with_indices do |e, *i|
+      self[*i] = e*alpha
     end
   end
 

--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -846,7 +846,6 @@ class NMatrix
     end.cast(self.stype, abs_dtype)
   end
 
-
   #
   # call-seq:
   #     absolute_sum -> Numeric
@@ -881,6 +880,41 @@ class NMatrix
   end
   alias :norm2 :nrm2
 
+  #
+  # call-seq:
+  #     scale! -> NMatrix
+  #
+  # == Arguments
+  #   - +alpha+ -> Scalar value used in the operation.
+  #   - +inc+ -> Increment used in the scaling function. Should generally be 1.
+  #   - +n+ -> Number of elements of +vector+.
+  #
+  # This is a destructive method, modifying the source NMatrix.  See also #scale.
+  # Return the scaling result of the matrix. BLAS scal will be invoked if provided.
+
+  def scale!(alpha, incx=1, n=nil)
+    raise(TypeError, "Invalid type of the scaling argument") unless
+        NMatrix::upcast(self.dtype, NMatrix::min_dtype(alpha)) == self.dtype
+    return NMatrix::BLAS::scal(alpha, self, incx, self.size / incx) if NMatrix::BLAS.method_defined? :scal
+    self.each_stored_with_indices do |e, i|
+      self[i] = e*alpha
+    end
+  end
+
+  #
+  # call-seq:
+  #     scale -> NMatrix
+  #
+  # == Arguments
+  #   - +alpha+ -> Scalar value used in the operation.
+  #   - +inc+ -> Increment used in the scaling function. Should generally be 1.
+  #   - +n+ -> Number of elements of +vector+.
+  #
+  # Return the scaling result of the matrix. BLAS scal will be invoked if provided.
+  
+  def scale(alpha, incx=1, n=nil)
+    return self.clone.scale!(alpha, incx, n)
+  end
 
   alias :permute_columns  :laswp
   alias :permute_columns! :laswp!

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -702,7 +702,7 @@ describe "math" do
                                                      360, 96, 51, -14,
                                                      448,-231,-24,-87,
                                                    -1168, 595,234, 523], 
-                                                   dtype: answer_dtype, 
+                                                   dtype: answer_dtype,
                                                    stype: stype))
         end
 
@@ -799,6 +799,40 @@ describe "math" do
             expect{@a.det_exact}.to raise_error(DataTypeError)
           else
             expect(@b.det_exact).to be_within(@err).of(-8)
+          end
+        end
+      end
+    end
+  end
+
+  context "#scale and #scale!" do
+    [:dense,:list,:yale].each do |stype|
+      ALL_DTYPES.each do |dtype|
+        next if dtype == :object
+        context "for #{dtype}" do
+          before do
+            @m = NMatrix.new([3, 3], [0, 1, 2,
+                                      3, 4, 5,
+                                      6, 7, 8], stype: stype, dtype: dtype)
+          end
+          it "scales the matrix by a given factor and return the result" do
+            if integer_dtype? dtype
+              expect{@m.scale 2.0}.to raise_error(DataTypeError)
+            else
+              expect(@m.scale 2.0).to eq(NMatrix.new([3, 3], [0,  2,  4,
+                                                             6,  8,  10,
+                                                             12, 14, 16], stype: stype, dtype: dtype))
+            end
+          end
+          it "scales the matrix in place by a given factor" do
+              if dtype == :int8
+                expect{@m.scale! 2}.to raise_error(DataTypeError)
+              else
+                @m.scale! 2
+                expect(@m).to eq(NMatrix.new([3, 3], [0,  2,  4,
+                                                      6,  8,  10,
+                                                      12, 14, 16], stype: stype, dtype: dtype))
+              end
           end
         end
       end


### PR DESCRIPTION
Fix #484 

New methods in math.rb: `#scale` and `#scale!`

Details:
- If data type of the scaling factor is not compatible for the original matrix (e.g. 2.0 and an int64 matrix), a `DataTypeError` will be raised.
- If **lapack**/**atlas** plugin exists, it will invoke **BLAS::SCAL**. Otherwise, a hand-made version will works.