### PR TITLE
Fixes to compile on windows using msys2

### DIFF
--- a/ext/nmatrix/data/data.cpp
+++ b/ext/nmatrix/data/data.cpp
@@ -198,39 +198,39 @@ const nm::dtype_t Upcast[nm::NUM_DTYPES][nm::NUM_DTYPES] = {
 void rubyval_to_cval(VALUE val, nm::dtype_t dtype, void* loc) {
   using namespace nm;
   switch (dtype) {
-    case BYTE:
+    case nm::BYTE:
       *reinterpret_cast<uint8_t*>(loc)      = static_cast<uint8_t>(RubyObject(val));
       break;
 
-    case INT8:
+    case nm::INT8:
       *reinterpret_cast<int8_t*>(loc)        = static_cast<int8_t>(RubyObject(val));
       break;
 
-    case INT16:
+    case nm::INT16:
       *reinterpret_cast<int16_t*>(loc)      = static_cast<int16_t>(RubyObject(val));
       break;
 
-    case INT32:
+    case nm::INT32:
       *reinterpret_cast<int32_t*>(loc)      = static_cast<int32_t>(RubyObject(val));
       break;
 
-    case INT64:
+    case nm::INT64:
       *reinterpret_cast<int64_t*>(loc)      = static_cast<int64_t>(RubyObject(val));
       break;
 
-    case FLOAT32:
+    case nm::FLOAT32:
       *reinterpret_cast<float32_t*>(loc)    = static_cast<float32_t>(RubyObject(val));
       break;
 
-    case FLOAT64:
+    case nm::FLOAT64:
       *reinterpret_cast<float64_t*>(loc)    = static_cast<float64_t>(RubyObject(val));
       break;
 
-    case COMPLEX64:
+    case nm::COMPLEX64:
       *reinterpret_cast<Complex64*>(loc)    = RubyObject(val).to<Complex64>();
       break;
 
-    case COMPLEX128:
+    case nm::COMPLEX128:
       *reinterpret_cast<Complex128*>(loc)    = RubyObject(val).to<Complex128>();
       break;
 

--- a/ext/nmatrix/storage/common.h
+++ b/ext/nmatrix/storage/common.h
@@ -34,6 +34,7 @@
 
 #include <ruby.h>
 #include <cmath> // pow().
+#include <type_traits>
 
 /*
  * Project Includes
@@ -44,6 +45,11 @@
 /*
  * Macros
  */
+
+#define u_int8_t static_assert(false, "Please use uint8_t for cross-platform support and consistency."); uint8_t
+#define u_int16_t static_assert(false, "Please use uint16_t for cross-platform support and consistency."); uint16_t
+#define u_int32_t static_assert(false, "Please use uint32_t for cross-platform support and consistency."); uint32_t
+#define u_int64_t static_assert(false, "Please use uint64_t for cross-platform support and consistency."); uint64_t
 
 extern "C" {
 
@@ -152,7 +158,7 @@ namespace nm {
   EWOP_INT_INT_DIV(int16_t, int32_t)
   EWOP_INT_INT_DIV(int16_t, int64_t)
   EWOP_INT_INT_DIV(int8_t, int8_t)
-  EWOP_INT_UINT_DIV(int8_t, u_int8_t)
+  EWOP_INT_UINT_DIV(int8_t, uint8_t)
   EWOP_INT_INT_DIV(int8_t, int16_t)
   EWOP_INT_INT_DIV(int8_t, int32_t)
   EWOP_INT_INT_DIV(int8_t, int64_t)
@@ -162,12 +168,12 @@ namespace nm {
   EWOP_UINT_INT_DIV(uint8_t, int32_t)
   EWOP_UINT_INT_DIV(uint8_t, int64_t)
   EWOP_FLOAT_INT_DIV(float, int8_t)
-  EWOP_FLOAT_INT_DIV(float, u_int8_t)
+  EWOP_FLOAT_INT_DIV(float, uint8_t)
   EWOP_FLOAT_INT_DIV(float, int16_t)
   EWOP_FLOAT_INT_DIV(float, int32_t)
   EWOP_FLOAT_INT_DIV(float, int64_t)
   EWOP_FLOAT_INT_DIV(double, int8_t)
-  EWOP_FLOAT_INT_DIV(double, u_int8_t)
+  EWOP_FLOAT_INT_DIV(double, uint8_t)
   EWOP_FLOAT_INT_DIV(double, int16_t)
   EWOP_FLOAT_INT_DIV(double, int32_t)
   EWOP_FLOAT_INT_DIV(double, int64_t)


### PR DESCRIPTION
I used these fixes to get the nmatrix gem (v0.2.1) working on Windows using mingw64 toolchain available through msys2 (https://msys2.github.io/). These fixes solve the following two issues:

- Types with names like u_int8_t not being available (this was bypassed using typedef to available types (uint8_t, uint16_t, ...).
- Ambiguous type errors since types like BYTE and INT8 are predefined on Windows (solved by using namespace qualifiers).

I am not sure if you would want to merge these changes, but the information in this pull request might be helpful to someone who is trying to use the gem on Windows (they might want to note that I already installed Lapack through msys2 package manager (pacman) using the recipe in https://github.com/Alexpux/MINGW-packages).

Note that there are issues with the g++ detection in the extconf.rb file that also prevent this gem from compiling on Windows using msys2 (mingw64) that these commits do not fix. I just bypassed the problem by bypassing the `gplusplus_version` method by making it return the version I was using (I did this on the "HackToFindG++" branch in my fork).