### PR TITLE
Fixes #det method for object dtypes

### DIFF
--- a/ext/nmatrix/data/complex.h
+++ b/ext/nmatrix/data/complex.h
@@ -110,11 +110,11 @@ class Complex {
   }
 
   /*
-   * Complex inverse function -- creates a copy, but inverted.
+   * Complex inverse (reciprocal) function -- computes 1 / n.
    *
    * FIXME: Check that this doesn't duplicate functionality of NativeType / Complex<Type>
    */
-  inline Complex<Type> inverse() const {
+  inline Complex<Type> reciprocal() const {
     Complex<Type> conj = conjugate();
     Type denom = this->r * this->r + this->i * this->i;
     return Complex<Type>(conj.r / denom, conj.i / denom);

--- a/ext/nmatrix/data/ruby_object.h
+++ b/ext/nmatrix/data/ruby_object.h
@@ -125,10 +125,19 @@ class RubyObject {
   inline RubyObject(const RubyObject& other) : rval(other.rval) {}
 
   /*
-   * Inverse operator.
+   * Quotient operator (typically for rational divisions)
    */
-  inline RubyObject inverse() const {
-    rb_raise(rb_eNotImpError, "RubyObject#inverse needs to be implemented");
+  inline RubyObject quo(const RubyObject& other) const {
+    return RubyObject(rb_funcall(this->rval, nm_rb_quo, 1, other.rval));
+  }
+  
+  /*
+   * Numeric inverse (reciprocal) operator, usually used for matrix
+   * operations like getrf. For this to work, Fixnum.quo(this) must not
+   * return a TypeError.
+   */
+  inline RubyObject reciprocal() const {
+    return RubyObject(rb_funcall(INT2FIX(1), nm_rb_quo, 1, this->rval));
   }
 
   /*

--- a/ext/nmatrix/math.cpp
+++ b/ext/nmatrix/math.cpp
@@ -207,7 +207,7 @@ namespace nm {
       } else if (M == 3) {
         x = A[lda+1] * A[2*lda+2] - A[lda+2] * A[2*lda+1]; // ei - fh
         y = A[lda] * A[2*lda+2] -   A[lda+2] * A[2*lda];   // fg - di
-        x = A[0]*x - A[1]*y ; // a*(ei-fh) - b*(fg-di)
+        x = A[0]*x - A[1]*y; // a*(ei-fh) - b*(fg-di)
 
         y = A[lda] * A[2*lda+1] - A[lda+1] * A[2*lda];    // dh - eg
         *result = A[2]*y + x; // c*(dh-eg) + _

--- a/ext/nmatrix/math.cpp
+++ b/ext/nmatrix/math.cpp
@@ -9,8 +9,8 @@
 //
 // == Copyright Information
 //
-// SciRuby is Copyright (c) 2010 - 2014, Ruby Science Foundation
-// NMatrix is Copyright (c) 2012 - 2014, John Woods and the Ruby Science Foundation
+// SciRuby is Copyright (c) 2010 - present, Ruby Science Foundation
+// NMatrix is Copyright (c) 2012 - present, John Woods and the Ruby Science Foundation
 //
 // Please see LICENSE.txt for additional copyright notices.
 //
@@ -134,6 +134,7 @@
 #include "math/cblas_enums.h"
 
 #include "data/data.h"
+#include "math/magnitude.h"
 #include "math/imax.h"
 #include "math/scal.h"
 #include "math/laswp.h"
@@ -237,11 +238,14 @@ namespace nm {
       int col_index[M];
 
       for (int k = 0;k < M; ++k) {
-        DType akk = std::abs( matrix[k * (M + 1)] ) ; // diagonal element
+        typename MagnitudeDType<DType>::type akk;
+        akk = magnitude( matrix[k * (M + 1)] ); // diagonal element
+
         int interchange = k;
 
         for (int row = k + 1; row < M; ++row) {
-          DType big = std::abs( matrix[M*row + k] ); // element below the temp pivot
+          typename MagnitudeDType<DType>::type big;
+          big = magnitude( matrix[M*row + k] ); // element below the temp pivot
           
           if ( big > akk ) {
             interchange = row;
@@ -748,16 +752,16 @@ static VALUE nm_cblas_nrm2(VALUE self, VALUE n, VALUE x, VALUE incx) {
 static VALUE nm_cblas_asum(VALUE self, VALUE n, VALUE x, VALUE incx) {
 
   static void (*ttable[nm::NUM_DTYPES])(const int N, const void* X, const int incX, void* sum) = {
-      nm::math::cblas_asum<uint8_t,uint8_t>,
-      nm::math::cblas_asum<int8_t,int8_t>,
-      nm::math::cblas_asum<int16_t,int16_t>,
-      nm::math::cblas_asum<int32_t,int32_t>,
-      nm::math::cblas_asum<int64_t,int64_t>,
-      nm::math::cblas_asum<float32_t,float32_t>,
-      nm::math::cblas_asum<float64_t,float64_t>,
-      nm::math::cblas_asum<float32_t,nm::Complex64>,
-      nm::math::cblas_asum<float64_t,nm::Complex128>,
-      nm::math::cblas_asum<nm::RubyObject,nm::RubyObject>
+      nm::math::cblas_asum<uint8_t>,
+      nm::math::cblas_asum<int8_t>,
+      nm::math::cblas_asum<int16_t>,
+      nm::math::cblas_asum<int32_t>,
+      nm::math::cblas_asum<int64_t>,
+      nm::math::cblas_asum<float32_t>,
+      nm::math::cblas_asum<float64_t>,
+      nm::math::cblas_asum<nm::Complex64>,
+      nm::math::cblas_asum<nm::Complex128>,
+      nm::math::cblas_asum<nm::RubyObject>
   };
 
   nm::dtype_t dtype  = NM_DTYPE(x);

--- a/ext/nmatrix/math/asum.h
+++ b/ext/nmatrix/math/asum.h
@@ -9,8 +9,8 @@
 //
 // == Copyright Information
 //
-// SciRuby is Copyright (c) 2010 - 2014, Ruby Science Foundation
-// NMatrix is Copyright (c) 2012 - 2014, John Woods and the Ruby Science Foundation
+// SciRuby is Copyright (c) 2010 - present, Ruby Science Foundation
+// NMatrix is Copyright (c) 2012 - present, John Woods and the Ruby Science Foundation
 //
 // Please see LICENSE.txt for additional copyright notices.
 //
@@ -60,6 +60,8 @@
 #define ASUM_H
 
 
+#include "math/magnitude.h"
+
 namespace nm { namespace math {
 
 /*
@@ -73,44 +75,21 @@ namespace nm { namespace math {
  *    complex64 -> float or double
  *    complex128 -> double
  */
-template <typename ReturnDType, typename DType>
-inline ReturnDType asum(const int N, const DType* X, const int incX) {
-  ReturnDType sum = 0;
+template <typename DType, typename MDType = typename MagnitudeDType<DType>::type>
+inline MDType asum(const int N, const DType* X, const int incX) {
+  MDType sum = 0;
   if ((N > 0) && (incX > 0)) {
     for (int i = 0; i < N; ++i) {
-      sum += std::abs(X[i*incX]);
+      sum += magnitude(X[i*incX]);
     }
   }
   return sum;
 }
 
 
-template <>
-inline float asum(const int N, const Complex64* X, const int incX) {
-  float sum = 0;
-  if ((N > 0) && (incX > 0)) {
-    for (int i = 0; i < N; ++i) {
-      sum += std::abs(X[i*incX].r) + std::abs(X[i*incX].i);
-    }
-  }
-  return sum;
-}
-
-template <>
-inline double asum(const int N, const Complex128* X, const int incX) {
-  double sum = 0;
-  if ((N > 0) && (incX > 0)) {
-    for (int i = 0; i < N; ++i) {
-      sum += std::abs(X[i*incX].r) + std::abs(X[i*incX].i);
-    }
-  }
-  return sum;
-}
-
-
-template <typename ReturnDType, typename DType>
+template <typename DType, typename MDType = typename MagnitudeDType<DType>::type>
 inline void cblas_asum(const int N, const void* X, const int incX, void* sum) {
-  *reinterpret_cast<ReturnDType*>( sum ) = asum<ReturnDType, DType>( N, reinterpret_cast<const DType*>(X), incX );
+  *reinterpret_cast<MDType*>( sum ) = asum<DType,MDType>( N, reinterpret_cast<const DType*>(X), incX );
 }
 
 

--- a/ext/nmatrix/math/cblas_templates_core.h
+++ b/ext/nmatrix/math/cblas_templates_core.h
@@ -107,9 +107,9 @@ inline void cblas_rot(const int N, void* X, const int incX, void* Y, const int i
  *    complex64 -> float or double
  *    complex128 -> double
  */
-template <typename ReturnDType, typename DType>
-inline ReturnDType asum(const int N, const DType* X, const int incX) {
-  return nm::math::asum<ReturnDType,DType>(N,X,incX);
+template <typename DType, typename MDType = typename MagnitudeDType<DType>::type>
+inline MDType asum(const int N, const DType* X, const int incX) {
+  return nm::math::asum<DType,MDType>(N,X,incX);
 }
 
 
@@ -134,9 +134,9 @@ inline double asum(const int N, const Complex128* X, const int incX) {
 }
 
 
-template <typename ReturnDType, typename DType>
+template <typename DType, typename MDType = typename MagnitudeDType<DType>::type>
 inline void cblas_asum(const int N, const void* X, const int incX, void* sum) {
-  *static_cast<ReturnDType*>( sum ) = asum<ReturnDType, DType>( N, static_cast<const DType*>(X), incX );
+  *static_cast<MDType*>( sum ) = asum<DType, MDType>( N, static_cast<const DType*>(X), incX );
 }
 
 /*
@@ -149,9 +149,9 @@ inline void cblas_asum(const int N, const void* X, const int incX, void* sum) {
  *    complex64 -> float or double
  *    complex128 -> double
  */
-template <typename ReturnDType, typename DType>
+template <typename DType, typename MDType = typename MagnitudeDType<DType>::type>
 inline ReturnDType nrm2(const int N, const DType* X, const int incX) {
-  return nm::math::nrm2<ReturnDType,DType>(N, X, incX);
+  return nm::math::nrm2<DType,MDType>(N, X, incX);
 }
 
 
@@ -175,9 +175,9 @@ inline double nrm2(const int N, const Complex128* X, const int incX) {
   return cblas_dznrm2(N, X, incX);
 }
 
-template <typename ReturnDType, typename DType>
+template <typename DType, typename MDType = typename MagnitudeDType<DType>::type>
 inline void cblas_nrm2(const int N, const void* X, const int incX, void* result) {
-  *static_cast<ReturnDType*>( result ) = nrm2<ReturnDType, DType>( N, static_cast<const DType*>(X), incX );
+  *static_cast<MDType*>( result ) = nrm2<DType, MDType>( N, static_cast<const DType*>(X), incX );
 }
 
 //imax

--- a/ext/nmatrix/math/getrf.h
+++ b/ext/nmatrix/math/getrf.h
@@ -9,8 +9,8 @@
 //
 // == Copyright Information
 //
-// SciRuby is Copyright (c) 2010 - 2014, Ruby Science Foundation
-// NMatrix is Copyright (c) 2012 - 2014, John Woods and the Ruby Science Foundation
+// SciRuby is Copyright (c) 2010 - present, Ruby Science Foundation
+// NMatrix is Copyright (c) 2012 - present, John Woods and the Ruby Science Foundation
 //
 // Please see LICENSE.txt for additional copyright notices.
 //
@@ -59,6 +59,7 @@
 #ifndef GETRF_H
 #define GETRF_H
 
+#include "math/reciprocal.h"
 #include "math/laswp.h"
 #include "math/math.h"
 #include "math/trsm.h"
@@ -67,14 +68,6 @@
 #include "math/scal.h"
 
 namespace nm { namespace math {
-
-/* Numeric inverse -- usually just 1 / f, but a little more complicated for complex. */
-template <typename DType>
-inline DType numeric_inverse(const DType& n) {
-  return n.inverse();
-}
-template <> inline float numeric_inverse(const float& n) { return 1 / n; }
-template <> inline double numeric_inverse(const double& n) { return 1 / n; }
 
 /*
  * Templated version of row-order and column-order getrf, derived from ATL_getrfR.c (from ATLAS 3.8.0).
@@ -170,7 +163,7 @@ inline int getrf_nothrow(const int M, const int N, DType* A, const int lda, int*
     DType tmp = A[i];
     if (tmp != 0) {
 
-      nm::math::scal<DType>((RowMajor ? N : M), nm::math::numeric_inverse(tmp), A, 1);
+      nm::math::scal<DType>((RowMajor ? N : M), nm::math::reciprocal(tmp), A, 1);
       A[i] = *A;
       *A   = tmp;
 

--- a/ext/nmatrix/math/getrf.h
+++ b/ext/nmatrix/math/getrf.h
@@ -125,10 +125,8 @@ inline int getrf_nothrow(const int M, const int N, DType* A, const int lda, int*
       An = &(Ar[N_ul]);
 
       nm::math::laswp<DType>(N_dr, Ar, lda, 0, N_ul, ipiv, 1);
-
       nm::math::trsm<DType>(CblasRowMajor, CblasRight, CblasUpper, CblasNoTrans, CblasUnit, N_dr, N_ul, one, A, lda, Ar, lda);
       nm::math::gemm<DType>(CblasRowMajor, CblasNoTrans, CblasNoTrans, N_dr, N-N_ul, N_ul, &neg_one, Ar, lda, Ac, lda, &one, An, lda);
-
       i = getrf_nothrow<true,DType>(N_dr, N-N_ul, An, lda, ipiv+N_ul);
     } else {
       Ar = NULL;
@@ -136,10 +134,8 @@ inline int getrf_nothrow(const int M, const int N, DType* A, const int lda, int*
       An = &(Ac[N_ul]);
 
       nm::math::laswp<DType>(N_dr, Ac, lda, 0, N_ul, ipiv, 1);
-
       nm::math::trsm<DType>(CblasColMajor, CblasLeft, CblasLower, CblasNoTrans, CblasUnit, N_ul, N_dr, one, A, lda, Ac, lda);
       nm::math::gemm<DType>(CblasColMajor, CblasNoTrans, CblasNoTrans, M-N_ul, N_dr, N_ul, &neg_one, &(A[N_ul]), lda, Ac, lda, &one, An, lda);
-
       i = getrf_nothrow<false,DType>(M-N_ul, N_dr, An, lda, ipiv+N_ul);
     }
 
@@ -150,7 +146,6 @@ inline int getrf_nothrow(const int M, const int N, DType* A, const int lda, int*
     }
 
     nm::math::laswp<DType>(N_ul, A, lda, N_ul, MN, ipiv, 1);  /* apply pivots */
-
   } else if (MN == 1) { // there's another case for the colmajor version, but it doesn't seem to be necessary.
 
     int i;
@@ -170,6 +165,7 @@ inline int getrf_nothrow(const int M, const int N, DType* A, const int lda, int*
     } else ierr = 1;
 
   }
+
   return(ierr);
 }
 

--- a/ext/nmatrix/math/imax.h
+++ b/ext/nmatrix/math/imax.h
@@ -9,8 +9,8 @@
 //
 // == Copyright Information
 //
-// SciRuby is Copyright (c) 2010 - 2014, Ruby Science Foundation
-// NMatrix is Copyright (c) 2012 - 2014, John Woods and the Ruby Science Foundation
+// SciRuby is Copyright (c) 2010 - present, Ruby Science Foundation
+// NMatrix is Copyright (c) 2012 - present, John Woods and the Ruby Science Foundation
 //
 // Please see LICENSE.txt for additional copyright notices.
 //
@@ -29,7 +29,10 @@
 #ifndef IMAX_H
 #define IMAX_H
 
+#include "math/magnitude.h"
+
 namespace nm { namespace math {
+
 
 template<typename DType>
 inline int imax(const int n, const DType *x, const int incx) {
@@ -41,28 +44,28 @@ inline int imax(const int n, const DType *x, const int incx) {
     return 0;
   }
 
-  DType dmax;
+  typename MagnitudeDType<DType>::type dmax;
   int imax = 0;
 
   if (incx == 1) { // if incrementing by 1
 
-    dmax = abs(x[0]);
+    dmax = magnitude(x[0]);
 
     for (int i = 1; i < n; ++i) {
-      if (std::abs(x[i]) > dmax) {
+      if (magnitude(x[i]) > dmax) {
         imax = i;
-        dmax = std::abs(x[i]);
+        dmax = magnitude(x[i]);
       }
     }
 
   } else { // if incrementing by more than 1
 
-    dmax = std::abs(x[0]);
+    dmax = magnitude(x[0]);
 
     for (int i = 1, ix = incx; i < n; ++i, ix += incx) {
-      if (std::abs(x[ix]) > dmax) {
+      if (magnitude(x[ix]) > dmax) {
         imax = i;
-        dmax = std::abs(x[ix]);
+        dmax = magnitude(x[ix]);
       }
     }
   }

--- a/ext/nmatrix/math/long_dtype.h
+++ b/ext/nmatrix/math/long_dtype.h
@@ -9,8 +9,8 @@
 //
 // == Copyright Information
 //
-// SciRuby is Copyright (c) 2010 - 2014, Ruby Science Foundation
-// NMatrix is Copyright (c) 2012 - 2014, John Woods and the Ruby Science Foundation
+// SciRuby is Copyright (c) 2010 - present, Ruby Science Foundation
+// NMatrix is Copyright (c) 2012 - present, John Woods and the Ruby Science Foundation
 //
 // Please see LICENSE.txt for additional copyright notices.
 //
@@ -23,7 +23,8 @@
 //
 // == long_dtype.h
 //
-// Declarations necessary for the native versions of GEMM and GEMV.
+// Declarations necessary for the native versions of GEMM and GEMV,
+// as well as for IMAX.
 //
 
 #ifndef LONG_DTYPE_H
@@ -44,6 +45,18 @@ namespace nm { namespace math {
   template <> struct LongDType<Complex128> { typedef Complex128 type; };
   template <> struct LongDType<RubyObject> { typedef RubyObject type; };
 
+  template <typename DType> struct MagnitudeDType;
+  template <> struct MagnitudeDType<uint8_t> { typedef uint8_t type; };
+  template <> struct MagnitudeDType<int8_t> { typedef int8_t type; };
+  template <> struct MagnitudeDType<int16_t> { typedef int16_t type; };
+  template <> struct MagnitudeDType<int32_t> { typedef int32_t type; };
+  template <> struct MagnitudeDType<int64_t> { typedef int64_t type; };
+  template <> struct MagnitudeDType<float> { typedef float type; };
+  template <> struct MagnitudeDType<double> { typedef double type; };
+  template <> struct MagnitudeDType<Complex64> { typedef float type; };
+  template <> struct MagnitudeDType<Complex128> { typedef double type; };
+  template <> struct MagnitudeDType<RubyObject> { typedef RubyObject type; };
+  
 }} // end of namespace nm::math
 
 #endif

--- a/ext/nmatrix/math/magnitude.h
+++ b/ext/nmatrix/math/magnitude.h
@@ -1,0 +1,54 @@
+/////////////////////////////////////////////////////////////////////
+// = NMatrix
+//
+// A linear algebra library for scientific computation in Ruby.
+// NMatrix is part of SciRuby.
+//
+// NMatrix was originally inspired by and derived from NArray, by
+// Masahiro Tanaka: http://narray.rubyforge.org
+//
+// == Copyright Information
+//
+// SciRuby is Copyright (c) 2010 - present, Ruby Science Foundation
+// NMatrix is Copyright (c) 2012 - present, John Woods and the Ruby Science Foundation
+//
+// Please see LICENSE.txt for additional copyright notices.
+//
+// == Contributing
+//
+// By contributing source code to SciRuby, you agree to be bound by
+// our Contributor Agreement:
+//
+// * https://github.com/SciRuby/sciruby/wiki/Contributor-Agreement
+//
+// == math/magnitude.h
+//
+// Takes the absolute value (meaning magnitude) of each DType.
+// Needed for a variety of BLAS/LAPACK functions.
+//
+
+#ifndef MAGNITUDE_H
+#define MAGNITUDE_H
+
+#include "math/long_dtype.h"
+
+namespace nm { namespace math {
+
+/* Magnitude -- may be complicated for unsigned types, and need to call the correct STL abs for floats/doubles */ 
+template <typename DType, typename MDType = typename MagnitudeDType<DType>::type>
+inline MDType magnitude(const DType& v) {
+  return v.abs();
+}
+template <> inline float magnitude(const float& v) { return std::abs(v); }
+template <> inline double magnitude(const double& v) { return std::abs(v); }
+template <> inline uint8_t magnitude(const uint8_t& v) { return v; }
+template <> inline int8_t magnitude(const int8_t& v) { return std::abs(v); }
+template <> inline int16_t magnitude(const int16_t& v) { return std::abs(v); }
+template <> inline int32_t magnitude(const int32_t& v) { return std::abs(v); }
+template <> inline int64_t magnitude(const int64_t& v) { return std::abs(v); }
+template <> inline float magnitude(const nm::Complex64& v) { return std::sqrt(v.r * v.r + v.i * v.i); }
+template <> inline double magnitude(const nm::Complex128& v) { return std::sqrt(v.r * v.r + v.i * v.i); } 
+    
+}}
+
+#endif // MAGNITUDE_H

--- a/ext/nmatrix/math/math.h
+++ b/ext/nmatrix/math/math.h
@@ -715,30 +715,6 @@ int getri(const int N, DType* A, const int lda, const int* ipiv, DType* wrk, con
 }
 */
 
-/*
- * Macro for declaring LAPACK specializations of the getrf function.
- *
- * type is the DType; call is the specific function to call; cast_as is what the DType* should be
- * cast to in order to pass it to LAPACK.
- */
-#define LAPACK_GETRF(type, call, cast_as)                                     \
-template <>                                                                   \
-inline int getrf(const enum CBLAS_ORDER Order, const int M, const int N, type * A, const int lda, int* ipiv) { \
-  int info = call(Order, M, N, reinterpret_cast<cast_as *>(A), lda, ipiv);    \
-  if (!info) return info;                                                     \
-  else {                                                                      \
-    rb_raise(rb_eArgError, "getrf: problem with argument %d\n", info);        \
-    return info;                                                              \
-  }                                                                           \
-}
-
-/* Specialize for ATLAS types */
-/*LAPACK_GETRF(float,      clapack_sgetrf, float)
-LAPACK_GETRF(double,     clapack_dgetrf, double)
-LAPACK_GETRF(Complex64,  clapack_cgetrf, void)
-LAPACK_GETRF(Complex128, clapack_zgetrf, void)
-*/
-
 }} // end namespace nm::math
 
 

--- a/ext/nmatrix/math/reciprocal.h
+++ b/ext/nmatrix/math/reciprocal.h
@@ -1,0 +1,48 @@
+/////////////////////////////////////////////////////////////////////
+// = NMatrix
+//
+// A linear algebra library for scientific computation in Ruby.
+// NMatrix is part of SciRuby.
+//
+// NMatrix was originally inspired by and derived from NArray, by
+// Masahiro Tanaka: http://narray.rubyforge.org
+//
+// == Copyright Information
+//
+// SciRuby is Copyright (c) 2010 - present, Ruby Science Foundation
+// NMatrix is Copyright (c) 2012 - present, John Woods and the Ruby Science Foundation
+//
+// Please see LICENSE.txt for additional copyright notices.
+//
+// == Contributing
+//
+// By contributing source code to SciRuby, you agree to be bound by
+// our Contributor Agreement:
+//
+// * https://github.com/SciRuby/sciruby/wiki/Contributor-Agreement
+//
+// == math/reciprocal.h
+//
+// Helper function for computing the reciprocal of a template type.
+// Called by getrf and possibly other things.
+//
+
+#ifndef RECIPROCAL_H
+#define RECIPROCAL_H
+
+
+namespace nm { namespace math {
+
+/* Numeric inverse -- basically just 1 / n, which in Ruby is 1.quo(n). */
+template <typename DType>
+inline DType reciprocal(const DType& n) {
+  return n.reciprocal();
+}
+template <> inline float reciprocal(const float& n) { return 1 / n; }
+template <> inline double reciprocal(const double& n) { return 1 / n; }
+
+}}
+
+
+#endif // RECIPROCAL_H
+

--- a/ext/nmatrix/math/trsm.h
+++ b/ext/nmatrix/math/trsm.h
@@ -58,6 +58,7 @@
 #ifndef TRSM_H
 #define TRSM_H
 
+#include "math/reciprocal.h"
 
 namespace nm { namespace math {
 
@@ -189,7 +190,7 @@ inline void trsm_nothrow(const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
             }
           }
           if (diag == CblasNonUnit) {
-            DType temp = 1 / a[j + j * lda];
+            DType temp = reciprocal(a[j + j * lda]);
             for (int i = 1; i <= m; ++i) {
               b[i + j * ldb] = temp * b[i + j * ldb];
             }
@@ -211,7 +212,7 @@ inline void trsm_nothrow(const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
             }
           }
           if (diag == CblasNonUnit) {
-            DType temp = 1 / a[j + j * lda];
+            DType temp = reciprocal(a[j + j * lda]);
 
             for (int i = 1; i <= m; ++i) {
               b[i + j * ldb] = temp * b[i + j * ldb];
@@ -226,7 +227,7 @@ inline void trsm_nothrow(const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
       if (uplo == CblasUpper) {
         for (int k = n; k >= 1; --k) {
           if (diag == CblasNonUnit) {
-            DType temp= 1 / a[k + k * lda];
+            DType temp = reciprocal(a[k + k * lda]);
             for (int i = 1; i <= m; ++i) {
               b[i + k * ldb] = temp * b[i + k * ldb];
             }
@@ -248,7 +249,7 @@ inline void trsm_nothrow(const enum CBLAS_SIDE side, const enum CBLAS_UPLO uplo,
       } else {
         for (int k = 1; k <= n; ++k) {
           if (diag == CblasNonUnit) {
-            DType temp = 1 / a[k + k * lda];
+            DType temp = reciprocal(a[k + k * lda]);
             for (int i = 1; i <= m; ++i) {
               b[i + k * ldb] = temp * b[i + k * ldb];
             }

--- a/ext/nmatrix/ruby_constants.cpp
+++ b/ext/nmatrix/ruby_constants.cpp
@@ -67,6 +67,7 @@ ID  nm_rb_dtype,
     nm_rb_sub,
     nm_rb_mul,
     nm_rb_div,
+    nm_rb_quo,
     nm_rb_both,
     nm_rb_none,
 
@@ -124,6 +125,7 @@ void nm_init_ruby_constants(void) {
   nm_rb_sub                = rb_intern("-");
   nm_rb_mul                = rb_intern("*");
   nm_rb_div                = rb_intern("/");
+  nm_rb_quo                = rb_intern("quo");
 
   nm_rb_negate            = rb_intern("-@");
 

--- a/ext/nmatrix/ruby_constants.h
+++ b/ext/nmatrix/ruby_constants.h
@@ -71,6 +71,7 @@ extern ID nm_rb_dtype,
           nm_rb_sub,
           nm_rb_mul,
           nm_rb_div,
+          nm_rb_quo,
 
           nm_rb_negate,
 

--- a/ext/nmatrix/ruby_nmatrix.c
+++ b/ext/nmatrix/ruby_nmatrix.c
@@ -2693,11 +2693,11 @@ static SLICE* get_slice(size_t dim, int argc, VALUE* arg, size_t* shape) {
       VALUE begin_end   = rb_funcall(v, rb_intern("shift"), 0); // rb_hash_shift
       nm_register_value(&begin_end);
 
-      if (rb_ary_entry(begin_end, 0) >= 0)
+      if (FIX2INT(rb_ary_entry(begin_end, 0)) >= 0)
         slice->coords[r]  = FIX2INT(rb_ary_entry(begin_end, 0));
       else
         slice->coords[r]  = shape[r] + FIX2INT(rb_ary_entry(begin_end, 0));
-      if (rb_ary_entry(begin_end, 1) >= 0)
+      if (FIX2INT(rb_ary_entry(begin_end, 1)) >= 0)
         slice->lengths[r] = FIX2INT(rb_ary_entry(begin_end, 1)) - slice->coords[r];
       else
         slice->lengths[r] = shape[r] + FIX2INT(rb_ary_entry(begin_end, 1)) - slice->coords[r];

--- a/ext/nmatrix_atlas/math_atlas.cpp
+++ b/ext/nmatrix_atlas/math_atlas.cpp
@@ -417,16 +417,16 @@ static VALUE nm_atlas_cblas_nrm2(VALUE self, VALUE n, VALUE x, VALUE incx) {
 static VALUE nm_atlas_cblas_asum(VALUE self, VALUE n, VALUE x, VALUE incx) {
 
   static void (*ttable[nm::NUM_DTYPES])(const int N, const void* X, const int incX, void* sum) = {
-      nm::math::atlas::cblas_asum<uint8_t,uint8_t>,
-      nm::math::atlas::cblas_asum<int8_t,int8_t>,
-      nm::math::atlas::cblas_asum<int16_t,int16_t>,
-      nm::math::atlas::cblas_asum<int32_t,int32_t>,
-      nm::math::atlas::cblas_asum<int64_t,int64_t>,
-      nm::math::atlas::cblas_asum<float32_t,float32_t>,
-      nm::math::atlas::cblas_asum<float64_t,float64_t>,
-      nm::math::atlas::cblas_asum<float32_t,nm::Complex64>,
-      nm::math::atlas::cblas_asum<float64_t,nm::Complex128>,
-      nm::math::atlas::cblas_asum<nm::RubyObject,nm::RubyObject>
+      nm::math::atlas::cblas_asum<uint8_t>,
+      nm::math::atlas::cblas_asum<int8_t>,
+      nm::math::atlas::cblas_asum<int16_t>,
+      nm::math::atlas::cblas_asum<int32_t>,
+      nm::math::atlas::cblas_asum<int64_t>,
+      nm::math::atlas::cblas_asum<float32_t>,
+      nm::math::atlas::cblas_asum<float64_t>,
+      nm::math::atlas::cblas_asum<nm::Complex64>,
+      nm::math::atlas::cblas_asum<nm::Complex128>,
+      nm::math::atlas::cblas_asum<nm::RubyObject>
   };
 
   nm::dtype_t dtype  = NM_DTYPE(x);

--- a/ext/nmatrix_lapacke/math_lapacke.cpp
+++ b/ext/nmatrix_lapacke/math_lapacke.cpp
@@ -369,16 +369,16 @@ static VALUE nm_lapacke_cblas_nrm2(VALUE self, VALUE n, VALUE x, VALUE incx) {
 static VALUE nm_lapacke_cblas_asum(VALUE self, VALUE n, VALUE x, VALUE incx) {
 
   static void (*ttable[nm::NUM_DTYPES])(const int N, const void* X, const int incX, void* sum) = {
-      nm::math::lapacke::cblas_asum<uint8_t,uint8_t>,
-      nm::math::lapacke::cblas_asum<int8_t,int8_t>,
-      nm::math::lapacke::cblas_asum<int16_t,int16_t>,
-      nm::math::lapacke::cblas_asum<int32_t,int32_t>,
-      nm::math::lapacke::cblas_asum<int64_t,int64_t>,
-      nm::math::lapacke::cblas_asum<float32_t,float32_t>,
-      nm::math::lapacke::cblas_asum<float64_t,float64_t>,
-      nm::math::lapacke::cblas_asum<float32_t,nm::Complex64>,
-      nm::math::lapacke::cblas_asum<float64_t,nm::Complex128>,
-      nm::math::lapacke::cblas_asum<nm::RubyObject,nm::RubyObject>
+      nm::math::lapacke::cblas_asum<uint8_t>,
+      nm::math::lapacke::cblas_asum<int8_t>,
+      nm::math::lapacke::cblas_asum<int16_t>,
+      nm::math::lapacke::cblas_asum<int32_t>,
+      nm::math::lapacke::cblas_asum<int64_t>,
+      nm::math::lapacke::cblas_asum<float32_t>,
+      nm::math::lapacke::cblas_asum<float64_t>,
+      nm::math::lapacke::cblas_asum<nm::Complex64>,
+      nm::math::lapacke::cblas_asum<nm::Complex128>,
+      nm::math::lapacke::cblas_asum<nm::RubyObject>
   };
 
   nm::dtype_t dtype  = NM_DTYPE(x);

--- a/lib/nmatrix/atlas.rb
+++ b/lib/nmatrix/atlas.rb
@@ -205,7 +205,7 @@ class NMatrix
   end
 
   def potrf!(which)
-    raise(StorageTypeError, "ATLAS functions only work on dense matrices") unless self.dense?
+    raise(StorageTypeError, "LAPACK functions only work on dense matrices") unless self.dense?
     raise(ShapeError, "Cholesky decomposition only valid for square matrices") unless self.dim == 2 && self.shape[0] == self.shape[1]
 
     NMatrix::LAPACK::clapack_potrf(:row, which, self.shape[0], self, self.shape[1])

--- a/lib/nmatrix/lapacke.rb
+++ b/lib/nmatrix/lapacke.rb
@@ -338,7 +338,7 @@ class NMatrix
   #   - +TypeError+ -> c must have the same dtype as the calling NMatrix
   #
   def unmqr(tau, side=:left, transpose=false, c=nil)
-    raise(StorageTypeError, "ATLAS functions only work on dense matrices") unless self.dense?
+    raise(StorageTypeError, "LAPACK functions only work on dense matrices") unless self.dense?
     raise(TypeError, "Works only on complex matrices, use ormqr for normal floating point matrices") unless self.complex_dtype?
     raise(TypeError, "c must have the same dtype as the calling NMatrix") if c and c.dtype != self.dtype
 

--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -130,10 +130,10 @@ class NMatrix
   # * *Returns* :
   #   - The IPIV vector. The L and U matrices are stored in A.
   # * *Raises* :
-  #   - +StorageTypeError+ -> ATLAS functions only work on dense matrices.
+  #   - +StorageTypeError+ -> LAPACK functions only work on dense matrices.
   #
   def getrf!
-    raise(StorageTypeError, "ATLAS functions only work on dense matrices") unless self.dense?
+    raise(StorageTypeError, "LAPACK functions only work on dense matrices") unless self.dense?
 
     #For row-major matrices, clapack_getrf uses a different convention than
     #described above (U has unit diagonal elements instead of L and columns
@@ -270,7 +270,7 @@ class NMatrix
   # * *Returns* :
   #   the triangular portion specified by the parameter
   # * *Raises* :
-  #   - +StorageTypeError+ -> ATLAS functions only work on dense matrices.
+  #   - +StorageTypeError+ -> LAPACK functions only work on dense matrices.
   #   - +ShapeError+ -> Must be square.
   #   - +NotImplementedError+ -> If called without nmatrix-atlas or nmatrix-lapacke gem
   #
@@ -568,7 +568,7 @@ class NMatrix
   # * +:covention+ - Possible values are +:lapack+ and +:intuitive+. Default is +:intuitive+. See above for details.
   #
   def laswp!(ary, opts={})
-    raise(StorageTypeError, "ATLAS functions only work on dense matrices") unless self.dense?
+    raise(StorageTypeError, "LAPACK functions only work on dense matrices") unless self.dense?
     opts = { convention: :intuitive }.merge(opts)
     
     if opts[:convention] == :intuitive

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -903,7 +903,7 @@ describe "math" do
 
   context "determinants" do
     ALL_DTYPES.each do |dtype|
-      next if dtype == :object
+      #next if dtype == :object
       context dtype do
         before do
           @a = NMatrix.new([2,2], [1,2,


### PR DESCRIPTION
Does not quite address #496, but I think I'm getting close.

Also depends on changes in #499.