### PR TITLE
Workaround for Windows having a different name for null device (extconf.rb)

### DIFF
--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -126,7 +126,10 @@ def find_newer_gplusplus #:nodoc:
 end
 
 def gplusplus_version
-  cxxvar = proc { |n| `#{CONFIG['CXX']} -E -dM - </dev/null | grep #{n}`.chomp.split(' ')[2] }
+  # Workaround for Windows having a different name for null device
+  null_device = (system 'echo "Hi" </dev/null') ? '/dev/null' : 'nul'
+
+  cxxvar = proc { |n| `#{CONFIG['CXX']} -E -dM - <#{null_device} | grep #{n}`.chomp.split(' ')[2] }
   major = cxxvar.call('__GNUC__')
   minor = cxxvar.call('__GNUC_MINOR__')
   patch = cxxvar.call('__GNUC_PATCHLEVEL__')


### PR DESCRIPTION
Tests if null device is available at `/dev/null`, if not, uses `nul` as null device.

Fix assumes that this gem only supports Windows, Unix and Unix-like systems (other operating systems may have different names for their null device).

Fix for issue #498.