### PR TITLE
Fix to include value number index when hash was passed to `NMatrix#[]`

### DIFF
--- a/ext/nmatrix/ruby_nmatrix.c
+++ b/ext/nmatrix/ruby_nmatrix.c
@@ -2697,10 +2697,11 @@ static SLICE* get_slice(size_t dim, int argc, VALUE* arg, size_t* shape) {
         slice->coords[r]  = FIX2INT(rb_ary_entry(begin_end, 0));
       else
         slice->coords[r]  = shape[r] + FIX2INT(rb_ary_entry(begin_end, 0));
+
       if (rb_ary_entry(begin_end, 1) >= 0)
-        slice->lengths[r] = FIX2INT(rb_ary_entry(begin_end, 1)) - slice->coords[r];
+        slice->lengths[r] = FIX2INT(rb_ary_entry(begin_end, 1)) - slice->coords[r] + 1;
       else
-        slice->lengths[r] = shape[r] + FIX2INT(rb_ary_entry(begin_end, 1)) - slice->coords[r];
+        slice->lengths[r] = shape[r] + FIX2INT(rb_ary_entry(begin_end, 1)) - slice->coords[r] + 1;
 
       if (RHASH_EMPTY_P(v)) t++; // go on to the next
       slice->single = false;

--- a/spec/00_nmatrix_spec.rb
+++ b/spec/00_nmatrix_spec.rb
@@ -555,6 +555,12 @@ describe 'NMatrix' do
       expect(n[-1]).to eq(5)
       expect(n[0,0..-2]).to eq(NMatrix.new([1,4],[1,2,3,4]))
     end
+
+    it "should work for hash" do
+      n = NMatrix.new([2,5], [1,2,3,4,5,6,7,8,9,0])
+      expect(n[0 => 1,3 => 4]).to eq NMatrix.new([2,2],[4,5,9,0])
+      expect(n[0 => 0,2 => 2]).to eq NMatrix.new([1,1],[3])
+    end
   end
 
   context "#complex_conjugate!" do


### PR DESCRIPTION
Comments of `get_slice` say "3:5 notation (inclusive)",
I think this means treating value number of hash as end index.