### PR TITLE
Preserve matrix dtype on repeat call

### DIFF
--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -1021,7 +1021,7 @@ class NMatrix
     raise(ArgumentError, 'Matrix should be repeated at least 2 times.') if count < 2
     new_shape = shape
     new_shape[axis] *= count
-    new_matrix = NMatrix.new(new_shape)
+    new_matrix = NMatrix.new(new_shape, dtype: dtype)
     slice = new_shape.map { |axis_size| 0...axis_size }
     start = 0
     count.times do

--- a/spec/00_nmatrix_spec.rb
+++ b/spec/00_nmatrix_spec.rb
@@ -706,6 +706,11 @@ describe 'NMatrix' do
       expect(@sample_matrix.repeat(2, 0)).to eq(NMatrix.new([4, 2], [1, 2, 3, 4, 1, 2, 3, 4]))
       expect(@sample_matrix.repeat(2, 1)).to eq(NMatrix.new([2, 4], [1, 2, 1, 2, 3, 4, 3, 4]))
     end
+
+    it "preserves dtype" do
+      expect(@sample_matrix.repeat(2, 0).dtype).to eq(@sample_matrix.dtype)
+      expect(@sample_matrix.repeat(2, 1).dtype).to eq(@sample_matrix.dtype)
+    end
   end
 
   context "#meshgrid" do


### PR DESCRIPTION
For now `repeat` sets resulting matrix `dtype` to `object`. This PR fixes it, preserving `dtype` of original matrix.