### PR TITLE
Fix NMatrix#concat implementation for case of different size along concat dimension

### DIFF
--- a/lib/nmatrix/nmatrix.rb
+++ b/lib/nmatrix/nmatrix.rb
@@ -710,16 +710,20 @@ class NMatrix
     # Do the actual construction.
     n = NMatrix.new(new_shape, opts)
 
-    # Figure out where to start and stop the concatenation. We'll use NMatrices instead of
-    # Arrays because then we can do elementwise addition.
-    ranges = self.shape.map.with_index { |s,i| 0...self.shape[i] }
+    # Figure out where to start concatenation. We don't know where it will end,
+    # because each matrix may have own size along concat dimension.
+    pos = Array.new(self.dim) { 0 }
 
     matrices.unshift(self)
     matrices.each do |m|
+      # Figure out where to start and stop the concatenation. We'll use
+      # NMatrices instead of Arrays because then we can do elementwise addition.
+      ranges = m.shape.map.with_index { |s,i| pos[i]...(pos[i] + s) }
+
       n[*ranges] = m
 
-      # move over by the requisite amount
-      ranges[rank]  = (ranges[rank].first + m.shape[rank])...(ranges[rank].last + m.shape[rank])
+      # Move over by the requisite amount
+      pos[rank] = pos[rank] + m.shape[rank]
     end
 
     n

--- a/spec/00_nmatrix_spec.rb
+++ b/spec/00_nmatrix_spec.rb
@@ -541,6 +541,26 @@ describe 'NMatrix' do
       n = NMatrix.new([1,3,1], [1,2,3])
       expect(n.dconcat(n)).to eq(NMatrix.new([1,3,2], [1,1,2,2,3,3]))
     end
+
+    it "should work on matrices with different size along concat dim" do
+      n = N[[1, 2, 3],
+            [4, 5, 6]]
+      m = N[[7],
+            [8]]
+
+      expect(n.hconcat(m)).to eq N[[1, 2, 3, 7], [4, 5, 6, 8]]
+      expect(m.hconcat(n)).to eq N[[7, 1, 2, 3], [8, 4, 5, 6]]
+    end
+
+    it "should work on matrices with different size along concat dim" do
+      n = N[[1, 2, 3],
+            [4, 5, 6]]
+
+      m = N[[7, 8, 9]]
+
+      expect(n.vconcat(m)).to eq N[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+      expect(m.vconcat(n)).to eq N[[7, 8, 9], [1, 2, 3], [4, 5, 6]]
+    end
   end
 
   context "#[]" do


### PR DESCRIPTION
Hi! I noticed that `NMatrix#hconcat` and `NMatrix#vconcat` fail or produce incorrect results in cases where matrix size differs on concatenating dimension, for example:


```
n = N[[1, 2, 3], 
      [4, 5, 6]]

m = N[[7, 8, 9]]

n.vconcat(m)
=> RangeError: slice is larger than matrix in dimension 0 (slice component 1)

m.vconcat(n).to_a
=> [[7, 8, 9], [1, 2, 3], [1683973494, 684649, 48]]
```

```
n = N[[1, 2, 3],
      [4, 5, 6]]

m = N[[7],
      [8]]

n.hconcat(m)
=> RangeError: slice is larger than matrix in dimension 1 (slice component 2)

m.hconcat(n).to_a
=> [[7, 1, 15357104, 21923], [8, 2, 25978, 33]]
```

After some investigation, I figured that implementation incorrectly uses range of same length for all matrices. This patch fixes it by moving start position only and recalculating range for each of matrix being concatenated.
