### PR TITLE
Fix C++ compiler selection

### DIFF
--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -25,48 +25,18 @@
 # This file checks for ATLAS and other necessary headers, and
 # generates a Makefile for compiling NMatrix.
 
-require "mkmf"
+require "nmatrix/mkmf"
 
-# Function derived from NArray's extconf.rb.
-def create_conf_h(file) #:nodoc:
-  print "creating #{file}\n"
-  File.open(file, 'w') do |hfile|
-    header_guard = file.upcase.sub(/\s|\./, '_')
-
-    hfile.puts "#ifndef #{header_guard}"
-    hfile.puts "#define #{header_guard}"
-    hfile.puts
-
-    # FIXME: Find a better way to do this:
-    hfile.puts "#define RUBY_2 1" if RUBY_VERSION >= '2.0'
-
-    for line in $defs
-      line =~ /^-D(.*)/
-      hfile.printf "#define %s 1\n", $1
-    end
-
-    hfile.puts
-    hfile.puts "#endif"
-  end
-end
-
-if RUBY_VERSION < '1.9'
-  raise(NotImplementedError, "Sorry, you need at least Ruby 1.9!")
-else
-  $INSTALLFILES = [
-    ['nmatrix.h'       , '$(archdir)'], 
-    ['nmatrix.hpp'     , '$(archdir)'],
-    ['nmatrix_config.h', '$(archdir)'], 
-    ['nm_memory.h'     , '$(archdir)'],
-    ['ruby_constants.h', '$(archdir)']
-  ]
-  if /cygwin|mingw/ =~ RUBY_PLATFORM
-    $INSTALLFILES << ['libnmatrix.a', '$(archdir)']
-  end
-end
+$INSTALLFILES = [
+  ['nmatrix.h'       , '$(archdir)'], 
+  ['nmatrix.hpp'     , '$(archdir)'],
+  ['nmatrix_config.h', '$(archdir)'], 
+  ['nm_memory.h'     , '$(archdir)'],
+  ['ruby_constants.h', '$(archdir)']
+]
 
 if /cygwin|mingw/ =~ RUBY_PLATFORM
-  CONFIG["DLDFLAGS"] << " --output-lib libnmatrix.a"
+  $INSTALLFILES << ['libnmatrix.a', '$(archdir)']
 end
 
 $DEBUG = true
@@ -79,78 +49,7 @@ basenames = %w{nmatrix ruby_constants data/data util/io math util/sl_list storag
 $objs = basenames.map { |b| "#{b}.o"   }
 $srcs = basenames.map { |b| "#{b}.cpp" }
 
-def find_newer_gplusplus #:nodoc:
-  print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
-  [9,8,7,6,5,4,3].each do |minor|
-    ver = "4.#{minor}"
-    gpp = "g++-#{ver}"
-    result = `which #{gpp}`
-    next if result.empty?
-    CONFIG['CXX'] = gpp
-    puts ver
-    return CONFIG['CXX']
-  end
-  false
-end
-
-def gplusplus_version
-  # Workaround for Windows having a different name for null device
-  null_device = (system 'echo "Hi" </dev/null') ? '/dev/null' : 'nul'
-
-  cxxvar = proc { |n| `#{CONFIG['CXX']} -E -dM - <#{null_device} | grep #{n}`.chomp.split(' ')[2] }
-  major = cxxvar.call('__GNUC__')
-  minor = cxxvar.call('__GNUC_MINOR__')
-  patch = cxxvar.call('__GNUC_PATCHLEVEL__')
-
-  raise("unable to determine g++ version (match to get version was nil)") if major.nil? || minor.nil? || patch.nil?
-
-  "#{major}.#{minor}.#{patch}"
-end
-
-if CONFIG['CC'] == 'clang' && CONFIG['CXX'] != 'clang++'
-  puts "WARNING: CONFIG['CXX'] is not 'clang++' in spite of CONFIG['CC'] is 'clang'.",
-       "WARNING: Force to use clang++ together with clang."
-
-  CONFIG['CXX'] = 'clang++'
-end
-
-if CONFIG['CXX'] == 'clang++'
-  $CXX_STANDARD = 'c++11'
-
-else
-  version = gplusplus_version
-  if version < '4.3.0' && CONFIG['CXX'] == 'g++'  # see if we can find a newer G++, unless it's been overridden by user
-    if !find_newer_gplusplus
-      raise("You need a version of g++ which supports -std=c++0x or -std=c++11. If you're on a Mac and using Homebrew, we recommend using mac-brew-gcc.sh to install a more recent g++.")
-    end
-    version = gplusplus_version
-  end
-
-  if version < '4.7.0'
-    $CXX_STANDARD = 'c++0x'
-  else
-    $CXX_STANDARD = 'c++11'
-  end
-  puts "using C++ standard... #{$CXX_STANDARD}"
-  puts "g++ reports version... " + `#{CONFIG['CXX']} --version|head -n 1|cut -f 3 -d " "`
-end
-
 #$libs += " -lprofiler "
-
-# For release, these next two should both be changed to -O3.
-$CFLAGS += " -O3 "
-#$CFLAGS += " -static -O0 -g "
-$CXXFLAGS += " -O3 -std=#{$CXX_STANDARD} " #-fmax-errors=10 -save-temps
-#$CXXFLAGS += " -static -O0 -g -std=#{$CXX_STANDARD} "
-
-CONFIG['warnflags'].gsub!('-Wshorten-64-to-32', '') # doesn't work except in Mac-patched gcc (4.2)
-CONFIG['warnflags'].gsub!('-Wdeclaration-after-statement', '')
-CONFIG['warnflags'].gsub!('-Wimplicit-function-declaration', '')
-
-have_func("rb_array_const_ptr", "ruby.h")
-have_macro("FIX_CONST_VALUE_PTR", "ruby.h")
-have_macro("RARRAY_CONST_PTR", "ruby.h")
-have_macro("RARRAY_AREF", "ruby.h")
 
 create_conf_h("nmatrix_config.h")
 create_makefile("nmatrix")

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -107,6 +107,12 @@ def gplusplus_version
   "#{major}.#{minor}.#{patch}"
 end
 
+if CONFIG['CC'] == 'clang' && CONFIG['CXX'] != 'clang++'
+  puts "WARNING: CONFIG['CXX'] is not 'clang++' in spite of CONFIG['CC'] is 'clang'.",
+       "WARNING: Force to use clang++ together with clang."
+
+  CONFIG['CXX'] = 'clang++'
+end
 
 if CONFIG['CXX'] == 'clang++'
   $CXX_STANDARD = 'c++11'

--- a/ext/nmatrix/extconf.rb
+++ b/ext/nmatrix/extconf.rb
@@ -27,38 +27,6 @@
 
 require "mkmf"
 
-
-# Function derived from NArray's extconf.rb.
-def have_type(type, header=nil) #:nodoc:
-  printf "checking for %s... ", type
-  STDOUT.flush
-
-  src = <<"SRC"
-#include <ruby.h>
-SRC
-
-
-  src << <<"SRC" unless header.nil?
-#include <#{header}>
-SRC
-
-  r = try_link(src + <<"SRC")
-  int main() { return 0; }
-  int t() { #{type} a; return 0; }
-SRC
-
-  unless r
-    print "no\n"
-    return false
-  end
-
-  $defs.push(format("-DHAVE_%s", type.upcase))
-
-  print "yes\n"
-
-  return true
-end
-
 # Function derived from NArray's extconf.rb.
 def create_conf_h(file) #:nodoc:
   print "creating #{file}\n"

--- a/ext/nmatrix_atlas/extconf.rb
+++ b/ext/nmatrix_atlas/extconf.rb
@@ -25,42 +25,11 @@
 # This file checks for ATLAS and other necessary headers, and
 # generates a Makefile for compiling NMatrix.
 
-require "mkmf"
+require "nmatrix/mkmf"
 
-# Function derived from NArray's extconf.rb.
-def create_conf_h(file) #:nodoc:
-  print "creating #{file}\n"
-  File.open(file, 'w') do |hfile|
-    header_guard = file.upcase.sub(/\s|\./, '_')
-
-    hfile.puts "#ifndef #{header_guard}"
-    hfile.puts "#define #{header_guard}"
-    hfile.puts
-
-    # FIXME: Find a better way to do this:
-    hfile.puts "#define RUBY_2 1" if RUBY_VERSION >= '2.0'
-
-    for line in $defs
-      line =~ /^-D(.*)/
-      hfile.printf "#define %s 1\n", $1
-    end
-
-    hfile.puts
-    hfile.puts "#endif"
-  end
-end
-
-if RUBY_VERSION < '1.9'
-  raise(NotImplementedError, "Sorry, you need at least Ruby 1.9!")
-else
-  #$INSTALLFILES = [['nmatrix.h', '$(archdir)'], ['nmatrix.hpp', '$(archdir)'], ['nmatrix_config.h', '$(archdir)'], ['nm_memory.h', '$(archdir)']]
-  if /cygwin|mingw/ =~ RUBY_PLATFORM
-    #$INSTALLFILES << ['libnmatrix.a', '$(archdir)']
-  end
-end
-
+#$INSTALLFILES = [['nmatrix.h', '$(archdir)'], ['nmatrix.hpp', '$(archdir)'], ['nmatrix_config.h', '$(archdir)'], ['nm_memory.h', '$(archdir)']]
 if /cygwin|mingw/ =~ RUBY_PLATFORM
-  CONFIG["DLDFLAGS"] << " --output-lib libnmatrix.a"
+  #$INSTALLFILES << ['libnmatrix.a', '$(archdir)']
 end
 
 $DEBUG = true
@@ -74,55 +43,6 @@ $CPPFLAGS = ["-Wall -Werror=return-type -I$(srcdir)/../nmatrix",$CPPFLAGS].join(
 basenames = %w{nmatrix_atlas math_atlas}
 $objs = basenames.map { |b| "#{b}.o"   }
 $srcs = basenames.map { |b| "#{b}.cpp" }
-
-def find_newer_gplusplus #:nodoc:
-  print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
-  [9,8,7,6,5,4,3].each do |minor|
-    ver = "4.#{minor}"
-    gpp = "g++-#{ver}"
-    result = `which #{gpp}`
-    next if result.empty?
-    CONFIG['CXX'] = gpp
-    puts ver
-    return CONFIG['CXX']
-  end
-  false
-end
-
-def gplusplus_version
-  cxxvar = proc { |n| `#{CONFIG['CXX']} -E -dM - </dev/null | grep #{n}`.chomp.split(' ')[2] }
-  major = cxxvar.call('__GNUC__')
-  minor = cxxvar.call('__GNUC_MINOR__')
-  patch = cxxvar.call('__GNUC_PATCHLEVEL__')
-
-  raise("unable to determine g++ version (match to get version was nil)") if major.nil? || minor.nil? || patch.nil?
-
-  "#{major}.#{minor}.#{patch}"
-end
-
-
-if CONFIG['CXX'] == 'clang++'
-  $CXX_STANDARD = 'c++11'
-
-else
-  version = gplusplus_version
-  if version < '4.3.0' && CONFIG['CXX'] == 'g++'  # see if we can find a newer G++, unless it's been overridden by user
-    if !find_newer_gplusplus
-      raise("You need a version of g++ which supports -std=c++0x or -std=c++11. If you're on a Mac and using Homebrew, we recommend using mac-brew-gcc.sh to install a more recent g++.")
-    end
-    version = gplusplus_version
-  end
-
-  if version < '4.7.0'
-    $CXX_STANDARD = 'c++0x'
-  else
-    $CXX_STANDARD = 'c++11'
-  end
-  puts "using C++ standard... #{$CXX_STANDARD}"
-  puts "g++ reports version... " + `#{CONFIG['CXX']} --version|head -n 1|cut -f 3 -d " "`
-end
-
-# add smmp in to get generic transp; remove smmp2 to eliminate funcptr transp
 
 # The next line allows the user to supply --with-atlas-dir=/usr/local/atlas,
 # --with-atlas-lib or --with-atlas-include and tell the compiler where to look
@@ -193,22 +113,6 @@ have_func("cblas_dgemm", "cblas.h")
 # Order matters here: ATLAS has to go after LAPACK: http://mail.scipy.org/pipermail/scipy-user/2007-January/010717.html
 $libs += " -llapack -lcblas -latlas "
 #$libs += " -lprofiler "
-
-
-# For release, these next two should both be changed to -O3.
-$CFLAGS += " -O3" #" -O0 -g "
-#$CFLAGS += " -static -O0 -g "
-$CXXFLAGS += " -O3 -std=#{$CXX_STANDARD}" #" -O0 -g -std=#{$CXX_STANDARD} " #-fmax-errors=10 -save-temps
-#$CPPFLAGS += " -static -O0 -g -std=#{$CXX_STANDARD} "
-
-CONFIG['warnflags'].gsub!('-Wshorten-64-to-32', '') # doesn't work except in Mac-patched gcc (4.2)
-CONFIG['warnflags'].gsub!('-Wdeclaration-after-statement', '')
-CONFIG['warnflags'].gsub!('-Wimplicit-function-declaration', '')
-
-have_func("rb_array_const_ptr", "ruby.h")
-have_macro("FIX_CONST_VALUE_PTR", "ruby.h")
-have_macro("RARRAY_CONST_PTR", "ruby.h")
-have_macro("RARRAY_AREF", "ruby.h")
 
 create_conf_h("nmatrix_atlas_config.h")
 create_makefile("nmatrix_atlas")

--- a/ext/nmatrix_atlas/extconf.rb
+++ b/ext/nmatrix_atlas/extconf.rb
@@ -27,38 +27,6 @@
 
 require "mkmf"
 
-
-# Function derived from NArray's extconf.rb.
-def have_type(type, header=nil) #:nodoc:
-  printf "checking for %s... ", type
-  STDOUT.flush
-
-  src = <<"SRC"
-#include <ruby.h>
-SRC
-
-
-  src << <<"SRC" unless header.nil?
-#include <#{header}>
-SRC
-
-  r = try_link(src + <<"SRC")
-  int main() { return 0; }
-  int t() { #{type} a; return 0; }
-SRC
-
-  unless r
-    print "no\n"
-    return false
-  end
-
-  $defs.push(format("-DHAVE_%s", type.upcase))
-
-  print "yes\n"
-
-  return true
-end
-
 # Function derived from NArray's extconf.rb.
 def create_conf_h(file) #:nodoc:
   print "creating #{file}\n"

--- a/ext/nmatrix_fftw/extconf.rb
+++ b/ext/nmatrix_fftw/extconf.rb
@@ -24,55 +24,7 @@
 #
 # This file checks FFTW3 and other necessary headers/shared objects.
 
-require 'mkmf'
-
-# Function derived from NArray's extconf.rb.
-def create_conf_h(file) #:nodoc:
-  print "creating #{file}\n"
-  File.open(file, 'w') do |hfile|
-    header_guard = file.upcase.sub(/\s|\./, '_')
-
-    hfile.puts "#ifndef #{header_guard}"
-    hfile.puts "#define #{header_guard}"
-    hfile.puts
-
-    # FIXME: Find a better way to do this:
-    hfile.puts "#define RUBY_2 1" if RUBY_VERSION >= '2.0'
-
-    for line in $defs
-      line =~ /^-D(.*)/
-      hfile.printf "#define %s 1\n", $1
-    end
-
-    hfile.puts
-    hfile.puts "#endif"
-  end
-end
-
-def find_newer_gplusplus #:nodoc:
-  print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
-  [9,8,7,6,5,4,3].each do |minor|
-    ver = "4.#{minor}"
-    gpp = "g++-#{ver}"
-    result = `which #{gpp}`
-    next if result.empty?
-    CONFIG['CXX'] = gpp
-    puts ver
-    return CONFIG['CXX']
-  end
-  false
-end
-
-def gplusplus_version
-  cxxvar = proc { |n| `#{CONFIG['CXX']} -E -dM - </dev/null | grep #{n}`.chomp.split(' ')[2] }
-  major = cxxvar.call('__GNUC__')
-  minor = cxxvar.call('__GNUC_MINOR__')
-  patch = cxxvar.call('__GNUC_PATCHLEVEL__')
-
-  raise("unable to determine g++ version (match to get version was nil)") if major.nil? || minor.nil? || patch.nil?
-
-  "#{major}.#{minor}.#{patch}"
-end
+require 'nmatrix/mkmf'
 
 fftw_libdir = RbConfig::CONFIG['libdir']
 fftw_incdir = RbConfig::CONFIG['includedir']
@@ -81,28 +33,6 @@ fftw_srcdir = RbConfig::CONFIG['srcdir']
 $CFLAGS = ["-Wall -Werror=return-type -I$(srcdir)/../nmatrix -I$(srcdir)/lapacke/include",$CFLAGS].join(" ")
 $CXXFLAGS = ["-Wall -Werror=return-type -I$(srcdir)/../nmatrix -I$(srcdir)/lapacke/include -std=c++11",$CXXFLAGS].join(" ")
 $CPPFLAGS = ["-Wall -Werror=return-type -I$(srcdir)/../nmatrix -I$(srcdir)/lapacke/include -std=c++11",$CPPFLAGS].join(" ")
-
-CONFIG['CXX'] = 'g++'
-
-if CONFIG['CXX'] == 'clang++'
-  $CPP_STANDARD = 'c++11'
-else
-  version = gplusplus_version
-  if version < '4.3.0' && CONFIG['CXX'] == 'g++'  # see if we can find a newer G++, unless it's been overridden by user
-    if !find_newer_gplusplus
-      raise("You need a version of g++ which supports -std=c++0x or -std=c++11. If you're on a Mac and using Homebrew, we recommend using mac-brew-gcc.sh to install a more recent g++.")
-    end
-    version = gplusplus_version
-  end
-
-  if version < '4.7.0'
-    $CPP_STANDARD = 'c++0x'
-  else
-    $CPP_STANDARD = 'c++11'
-  end
-  puts "using C++ standard... #{$CPP_STANDARD}"
-  puts "g++ reports version... " + `#{CONFIG['CXX']} --version|head -n 1|cut -f 3 -d " "`
-end
 
 flags = " --include=#{fftw_incdir} --libdir=#{fftw_libdir}"
 

--- a/ext/nmatrix_lapacke/extconf.rb
+++ b/ext/nmatrix_lapacke/extconf.rb
@@ -27,38 +27,6 @@
 
 require "mkmf"
 
-
-# Function derived from NArray's extconf.rb.
-def have_type(type, header=nil) #:nodoc:
-  printf "checking for %s... ", type
-  STDOUT.flush
-
-  src = <<"SRC"
-#include <ruby.h>
-SRC
-
-
-  src << <<"SRC" unless header.nil?
-#include <#{header}>
-SRC
-
-  r = try_link(src + <<"SRC")
-  int main() { return 0; }
-  int t() { #{type} a; return 0; }
-SRC
-
-  unless r
-    print "no\n"
-    return false
-  end
-
-  $defs.push(format("-DHAVE_%s", type.upcase))
-
-  print "yes\n"
-
-  return true
-end
-
 # Function derived from NArray's extconf.rb.
 def create_conf_h(file) #:nodoc:
   print "creating #{file}\n"

--- a/ext/nmatrix_lapacke/extconf.rb
+++ b/ext/nmatrix_lapacke/extconf.rb
@@ -25,42 +25,11 @@
 # This file checks for ATLAS and other necessary headers, and
 # generates a Makefile for compiling NMatrix.
 
-require "mkmf"
+require "nmatrix/mkmf"
 
-# Function derived from NArray's extconf.rb.
-def create_conf_h(file) #:nodoc:
-  print "creating #{file}\n"
-  File.open(file, 'w') do |hfile|
-    header_guard = file.upcase.sub(/\s|\./, '_')
-
-    hfile.puts "#ifndef #{header_guard}"
-    hfile.puts "#define #{header_guard}"
-    hfile.puts
-
-    # FIXME: Find a better way to do this:
-    hfile.puts "#define RUBY_2 1" if RUBY_VERSION >= '2.0'
-
-    for line in $defs
-      line =~ /^-D(.*)/
-      hfile.printf "#define %s 1\n", $1
-    end
-
-    hfile.puts
-    hfile.puts "#endif"
-  end
-end
-
-if RUBY_VERSION < '1.9'
-  raise(NotImplementedError, "Sorry, you need at least Ruby 1.9!")
-else
-  #$INSTALLFILES = [['nmatrix.h', '$(archdir)'], ['nmatrix.hpp', '$(archdir)'], ['nmatrix_config.h', '$(archdir)'], ['nm_memory.h', '$(archdir)']]
-  if /cygwin|mingw/ =~ RUBY_PLATFORM
-    #$INSTALLFILES << ['libnmatrix.a', '$(archdir)']
-  end
-end
-
+#$INSTALLFILES = [['nmatrix.h', '$(archdir)'], ['nmatrix.hpp', '$(archdir)'], ['nmatrix_config.h', '$(archdir)'], ['nm_memory.h', '$(archdir)']]
 if /cygwin|mingw/ =~ RUBY_PLATFORM
-  CONFIG["DLDFLAGS"] << " --output-lib libnmatrix.a"
+  #$INSTALLFILES << ['libnmatrix.a', '$(archdir)']
 end
 
 $DEBUG = true
@@ -75,56 +44,6 @@ basenames = %w{nmatrix_lapacke math_lapacke lapacke}
 $objs = basenames.map { |b| "#{b}.o"   }
 $srcs = basenames.map { |b| "#{b}.cpp" }
 
-def find_newer_gplusplus #:nodoc:
-  print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
-  [9,8,7,6,5,4,3].each do |minor|
-    ver = "4.#{minor}"
-    gpp = "g++-#{ver}"
-    result = `which #{gpp}`
-    next if result.empty?
-    CONFIG['CXX'] = gpp
-    puts ver
-    return CONFIG['CXX']
-  end
-  false
-end
-
-def gplusplus_version
-  cxxvar = proc { |n| `#{CONFIG['CXX']} -E -dM - </dev/null | grep #{n}`.chomp.split(' ')[2] }
-  major = cxxvar.call('__GNUC__')
-  minor = cxxvar.call('__GNUC_MINOR__')
-  patch = cxxvar.call('__GNUC_PATCHLEVEL__')
-
-  raise("unable to determine g++ version (match to get version was nil)") if major.nil? || minor.nil? || patch.nil?
-
-  "#{major}.#{minor}.#{patch}"
-end
-
-
-if CONFIG['CXX'] == 'clang++'
-  $CXX_STANDARD = 'c++11'
-
-else
-  version = gplusplus_version
-  if version < '4.3.0' && CONFIG['CXX'] == 'g++'  # see if we can find a newer G++, unless it's been overridden by user
-    if !find_newer_gplusplus
-      raise("You need a version of g++ which supports -std=c++0x or -std=c++11. If you're on a Mac and using Homebrew, we recommend using mac-brew-gcc.sh to install a more recent g++.")
-    end
-    version = gplusplus_version
-  end
-
-  if version < '4.7.0'
-    $CXX_STANDARD = 'c++0x'
-  else
-    $CXX_STANDARD = 'c++11'
-  end
-  puts "using C++ standard... #{$CXX_STANDARD}"
-  puts "g++ reports version... " + `#{CONFIG['CXX']} --version|head -n 1|cut -f 3 -d " "`
-end
-
-# add smmp in to get generic transp; remove smmp2 to eliminate funcptr transp
-
-
 # For some reason, if we try to look for /usr/lib64/atlas on a Mac OS X Mavericks system, and the directory does not
 # exist, it will give a linker error -- even if the lib dir is already correctly included with -L. So we need to check
 # that Dir.exists?(d) for each.
@@ -138,31 +57,11 @@ unless have_library("lapack")
   dir_config("lapack", idefaults[:lapack], ldefaults[:lapack])
 end
 
-
-
-#have_func("rb_scan_args", "ruby.h")
-
 # Order matters here: ATLAS has to go after LAPACK: http://mail.scipy.org/pipermail/scipy-user/2007-January/010717.html
 $libs += " -llapack "
 #To use the Intel MKL, comment out the line above, and also comment out the bit above with have_library and dir_config for lapack.
 #Then add something like the line below (for exactly what linker flags to use see https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor ):
 #$libs += " -L${MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential "
-
-
-# For release, these next two should both be changed to -O3.
-$CFLAGS += " -O3" #" -O0 -g "
-#$CFLAGS += " -static -O0 -g "
-$CXXFLAGS += " -O3 -std=#{$CXX_STANDARD}" #" -O0 -g -std=#{$CXX_STANDARD} " #-fmax-errors=10 -save-temps
-#$CPPFLAGS += " -static -O0 -g -std=#{$CXX_STANDARD} "
-
-CONFIG['warnflags'].gsub!('-Wshorten-64-to-32', '') # doesn't work except in Mac-patched gcc (4.2)
-CONFIG['warnflags'].gsub!('-Wdeclaration-after-statement', '')
-CONFIG['warnflags'].gsub!('-Wimplicit-function-declaration', '')
-
-have_func("rb_array_const_ptr", "ruby.h")
-have_macro("FIX_CONST_VALUE_PTR", "ruby.h")
-have_macro("RARRAY_CONST_PTR", "ruby.h")
-have_macro("RARRAY_AREF", "ruby.h")
 
 create_conf_h("nmatrix_lapacke_config.h")
 create_makefile("nmatrix_lapacke")

--- a/lib/nmatrix/mkmf.rb
+++ b/lib/nmatrix/mkmf.rb
@@ -1,0 +1,103 @@
+require "mkmf"
+
+if RUBY_VERSION < '1.9'
+  raise NotImplementedError, "Sorry, you need at least Ruby 1.9!"
+end
+
+# Function derived from NArray's extconf.rb.
+def create_conf_h(file) #:nodoc:
+  print "creating #{file}\n"
+  File.open(file, 'w') do |hfile|
+    header_guard = file.upcase.sub(/\s|\./, '_')
+
+    hfile.puts "#ifndef #{header_guard}"
+    hfile.puts "#define #{header_guard}"
+    hfile.puts
+
+    # FIXME: Find a better way to do this:
+    hfile.puts "#define RUBY_2 1" if RUBY_VERSION >= '2.0'
+
+    for line in $defs
+      line =~ /^-D(.*)/
+      hfile.printf "#define %s 1\n", $1
+    end
+
+    hfile.puts
+    hfile.puts "#endif"
+  end
+end
+
+def find_newer_gplusplus #:nodoc:
+  print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
+  [9,8,7,6,5,4,3].each do |minor|
+    ver = "4.#{minor}"
+    gpp = "g++-#{ver}"
+    result = `which #{gpp}`
+    next if result.empty?
+    CONFIG['CXX'] = gpp
+    puts ver
+    return CONFIG['CXX']
+  end
+  false
+end
+
+def gplusplus_version
+  cxxvar = proc { |n| `#{CONFIG['CXX']} -E -dM - <#{File::NULL} | grep #{n}`.chomp.split(' ')[2] }
+  major = cxxvar.call('__GNUC__')
+  minor = cxxvar.call('__GNUC_MINOR__')
+  patch = cxxvar.call('__GNUC_PATCHLEVEL__')
+
+  raise("unable to determine g++ version (match to get version was nil)") if major.nil? || minor.nil? || patch.nil?
+
+  "#{major}.#{minor}.#{patch}"
+end
+
+
+if /cygwin|mingw/ =~ RUBY_PLATFORM
+  CONFIG["DLDFLAGS"] << " --output-lib libnmatrix.a"
+end
+
+# Fix compiler pairing
+if CONFIG['CC'] == 'clang' && CONFIG['CXX'] != 'clang++'
+  puts "WARNING: CONFIG['CXX'] is not 'clang++' even though CONFIG['CC'] is 'clang'.",
+       "WARNING: Force to use clang++ together with clang."
+
+  CONFIG['CXX'] = 'clang++'
+end
+
+if CONFIG['CXX'] == 'clang++'
+  $CXX_STANDARD = 'c++11'
+else
+  version = gplusplus_version
+  if version < '4.3.0' && CONFIG['CXX'] == 'g++'  # see if we can find a newer G++, unless it's been overridden by user
+    if !find_newer_gplusplus
+      raise("You need a version of g++ which supports -std=c++0x or -std=c++11. If you're on a Mac and using Homebrew, we recommend using mac-brew-gcc.sh to install a more recent g++.")
+    end
+    version = gplusplus_version
+  end
+
+  if version < '4.7.0'
+    $CXX_STANDARD = 'c++0x'
+  else
+    $CXX_STANDARD = 'c++11'
+  end
+  puts "using C++ standard... #{$CXX_STANDARD}"
+  puts "g++ reports version... " + `#{CONFIG['CXX']} --version|head -n 1|cut -f 3 -d " "`
+end
+
+# For release, these next two should both be changed to -O3.
+$CFLAGS += " -O3 "
+#$CFLAGS += " -static -O0 -g "
+$CXXFLAGS += " -O3 -std=#{$CXX_STANDARD} " #-fmax-errors=10 -save-temps
+#$CXXFLAGS += " -static -O0 -g -std=#{$CXX_STANDARD} "
+
+CONFIG['warnflags'].gsub!('-Wshorten-64-to-32', '') # doesn't work except in Mac-patched gcc (4.2)
+CONFIG['warnflags'].gsub!('-Wdeclaration-after-statement', '')
+CONFIG['warnflags'].gsub!('-Wimplicit-function-declaration', '')
+
+have_func("rb_array_const_ptr", "ruby.h")
+have_macro("FIX_CONST_VALUE_PTR", "ruby.h")
+have_macro("RARRAY_CONST_PTR", "ruby.h")
+have_macro("RARRAY_AREF", "ruby.h")
+
+


### PR DESCRIPTION
~~**NOTE**: please merge #524 before this because this pull-request based on that pull-request.~~

This pull-request allows us to select the collect combination of C++ and C compilers on OS X.

In Ruby < 2.4, configure script couldn't select the collect C++ compiler for the specified C compiler (I've fixed it on Ruby 2.4).
The changes in this is overwrite CXX variable to `clang++` when CC is `clang`.

#525 will be fixed by this.