### PR TITLE
Add #least_squares for least squares approximation

### DIFF
--- a/lib/nmatrix/lapacke.rb
+++ b/lib/nmatrix/lapacke.rb
@@ -303,7 +303,7 @@ class NMatrix
 
 
     #Default behaviour produces Q * I  = Q if c is not supplied.
-    result = c ? c : NMatrix.identity(self.shape[0], dtype: self.dtype)
+    result = c ? c.clone : NMatrix.identity(self.shape[0], dtype: self.dtype)
     NMatrix::LAPACK::lapacke_ormqr(:row, side, transpose, result.shape[0], result.shape[1], tau.shape[0], self, self.shape[1], tau, result, result.shape[1])
     
     result
@@ -343,7 +343,7 @@ class NMatrix
     raise(TypeError, "c must have the same dtype as the calling NMatrix") if c and c.dtype != self.dtype
 
     #Default behaviour produces Q * I  = Q if c is not supplied.
-    result = c ? c : NMatrix.identity(self.shape[0], dtype: self.dtype)
+    result = c ? c.clone : NMatrix.identity(self.shape[0], dtype: self.dtype)
     NMatrix::LAPACK::lapacke_unmqr(:row, side, transpose, result.shape[0], result.shape[1], tau.shape[0], self, self.shape[1], tau, result, result.shape[1])
     
     result

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -849,6 +849,34 @@ describe "math" do
     end
   end
 
+  context "#least_squares" do
+    it "finds the least squares approximation to the equation A * X = B" do
+      a = NMatrix.new([3,2], [2.0, 0, -1, 1, 0, 2]) 
+      b = NMatrix.new([3,1], [1.0, 0, -1])
+      solution = NMatrix.new([2,1], [1.0 / 3 , -1.0 / 3], dtype: :float64)
+    
+      begin
+        least_squares = a.least_squares(b)
+        expect(least_squares).to be_within(0.0001).of solution
+      rescue NotImplementedError
+        "Suppressing a NotImplementedError when the lapacke or atlas plugin is not available"
+      end
+    end
+    
+    it "finds the least squares approximation to the equation A * X = B with high tolerance" do
+      a = NMatrix.new([4,2], [1.0, 1, 1, 2, 1, 3,1,4]) 
+      b = NMatrix.new([4,1], [6.0, 5, 7, 10])
+      solution = NMatrix.new([2,1], [3.5 , 1.4], dtype: :float64)
+    
+      begin
+        least_squares = a.least_squares(b, tolerance: 10e-5)
+        expect(least_squares).to be_within(0.0001).of solution
+      rescue NotImplementedError
+        "Suppressing a NotImplementedError when the lapacke or atlas plugin is not available"
+      end
+    end    
+  end
+
   context "#hessenberg" do
     FLOAT_DTYPES.each do |dtype|
       context dtype do


### PR DESCRIPTION
Fixes #513 

Commits :-  

1) Slight modification of `#unmqr` and `#ormqr` to prevent one of the input multiplicands from being overwritten

2) Adding of `#least_squares`

Usage :-

```ruby

a = NMatrix.new([3,2], [2.0, 0, -1, 1, 0, 2]) 
b = NMatrix.new([3,1], [1.0, 0, -1])

a.least_squares(b)

=> 
[
  [0.33333333333333326]
  [-0.3333333333333334]
]
```
Currently only works for matrices that are not rank-deficient which can be tackled when QR factorization with column pivoting gets wrapped from Lapack. Would add a few more tests very soon.
