### PR TITLE
fixes det method for dtype object

### DIFF
--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -767,7 +767,7 @@ class NMatrix
     raise(ShapeError, "determinant can be calculated only for square matrices") unless self.dim == 2 && self.shape[0] == self.shape[1]
 
     # Cast to a dtype for which getrf is implemented
-    new_dtype = self.integer_dtype? ? :float64 : self.dtype
+    new_dtype = self.integer_dtype? || self.object_dtype? ? :float64 : self.dtype
     copy = self.cast(:dense, new_dtype)
 
     # Need to know the number of permutations. We'll add up the diagonals of

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -1032,19 +1032,13 @@ describe "math" do
                 end
         end
         it "computes the determinant of 2x2 matrix" do
-          if dtype != :object
             expect(@a.det).to be_within(@err).of(-2)
-          end
         end
         it "computes the determinant of 3x3 matrix" do
-          if dtype != :object
             expect(@b.det).to be_within(@err).of(-8)
-          end
         end
         it "computes the determinant of 4x4 matrix" do
-          if dtype != :object
             expect(@c.det).to be_within(@err).of(-18)
-          end
         end
         it "computes the exact determinant of 2x2 matrix" do
           if dtype == :byte


### PR DESCRIPTION
@mohawkjohn In continuation with the work done by you in PR #501.
