### PR TITLE
created #positive_semidefinite? method

### DIFF
--- a/lib/nmatrix/math.rb
+++ b/lib/nmatrix/math.rb
@@ -1179,6 +1179,36 @@ class NMatrix
   alias :permute_columns  :laswp
   alias :permute_columns! :laswp!
 
+  #
+  #call-seq:
+  #    positive_semidefinite? -> boolean
+  #
+  # A matrix is positive semidefinite if all of its eigenvalues are non-negative.
+  #
+  # * *Returns* :
+  #   - A booloean value telling if the NMatrix is positive semidefinite or not.
+  # * *Raises* :
+  #   - +ShapeError+ -> Must be used on square matrices
+  #
+  def positive_semidefinite?
+    raised(ShapeError, "positive semidefinite calculated only for square matrices")unless
+      self.dim == 2 && self.shape[0] == self.shape[1]
+    # Cast to a dtype for which geev is implemented
+    new_dtype = self.integer_dtype? ? :float64 : self.dtype
+    copy = self.cast(:dense, new_dtype)
+    eigenvalues = NMatrix::LAPACK.geev(copy, :left)
+    ans = true
+    ind = 0
+    while ind != self.dim
+      if eigenvalues[0][ind].real < 0
+        ans = false
+        break
+      end
+      ind =ind + 1
+    end
+    ans
+  end
+
 protected
   # Define the element-wise operations for lists. Note that the __list_map_merged_stored__ iterator returns a Ruby Object
   # matrix, which we then cast back to the appropriate type. If you don't want that, you can redefine these functions in

--- a/spec/math_spec.rb
+++ b/spec/math_spec.rb
@@ -1101,4 +1101,16 @@ describe "math" do
       end
     end
   end
+
+  context "#positive_semidefinite? " do
+    it "should return true for positive_semidefinite? matrix" do
+      n = NMatrix.new([2,2], [1, 2,
+                              -2, 1])
+      begin
+        expect(n.positive_semidefinite?).to be_truthy
+      rescue NotImplementedError => e
+        pending e.to_s
+      end
+    end
+  end
 end


### PR DESCRIPTION
Created the #positive_semidefinite? addressed in issue #411. I first looked into the PR #561 to construct the method but I realized that non-negativity of the principal minor is not the sufficient case for a matrix to be positive semidefinite which is true for the case of positive definite so i used geev function to check that all the eigenvalues are non negative. Please tell me if there is any other way to solve the problem.

@mohawkjohn eigenvalues are non-negative.