### PR TITLE
Added script to make nmatrix-fftw gem compile on Windows (ruby -v: ru…

### DIFF
--- a/ext/nmatrix_fftw/extconf.rb
+++ b/ext/nmatrix_fftw/extconf.rb
@@ -38,6 +38,11 @@ flags = " --include=#{fftw_incdir} --libdir=#{fftw_libdir}"
 
 if have_library("fftw3")
   $CFLAGS += [" -lfftw3 -lm #{$CFLAGS} #{$flags}"].join(" ")
+
+  if ENV['OS'] == 'Windows_NT'
+    $DLDFLAGS += ' -lnmatrix '
+  end
+
   dir_config('nmatrix_fftw', fftw_incdir, fftw_libdir)
   dir_config('nmatrix_fftw')
 end

--- a/manual_fftw_compilation.sh
+++ b/manual_fftw_compilation.sh
@@ -1,0 +1,7 @@
+
+MAKE='make V=1 -j4' bundle exec rake compile nmatrix_plugins="fftw"
+cd tmp/x64-mingw32/nmatrix/2.5.0/
+ar cr libnmatrix.a nmatrix.o ruby_constants.o data/data.o util/io.o math.o util/sl_list.o storage/common.o storage/storage.o storage/dense/dense.o storage/yale/yale.o storage/list/list.o
+cd ../../../../
+mv tmp/x64-mingw32/nmatrix/2.5.0/libnmatrix.a tmp/x64-mingw32/nmatrix_fftw/2.5.0/
+MAKE='make V=1 -j4' bundle exec rake compile nmatrix_plugins="fftw"


### PR DESCRIPTION
…by 2.5.0p0 (2017-12-25 revision 61468) [x64-mingw32]) using MSYS2 MINGW64 for testing purposes.

This pull request is to mainly get feedback (related to https://github.com/SciRuby/nmatrix/issues/600). It contains a manual fix (you have to run a shell script `sh manual_fftw_compilation.sh` in the root of the directory and it only works for the mingw64 ruby version installed using msys2 (`pacman -S mingw-w64-x86_64-ruby`) from the mingw64 command line) for the nmatrix-fftw gem to compile (all tests pass by the way). It is based on the second part of the feedback given in https://github.com/SciRuby/nmatrix/issues/600#issuecomment-347107459 by @larskanis.

The fix applied to nmatrix-fftw should work for nmatrix-lapacke and nmatrix-atlas (but I encountered installing the C/C++/Fortran dependencies for these on Windows) as they are affected by the same dynamic loading issues. These issues could be resolved if the C extension components of the nmatrix-fftw, nmatrix-lapacke and nmatrix-atlas gems did not rely on dynamically linking with the C extension component of nmatrix at runtime (is dynamic linking used for performance reasons?). I'm not aware of any other gem that relies on its C extension component dynamically linking with another gem's C extension's during runtime (an example of a gem that relies on this behaviour and works on Windows would be useful).

Also https://github.com/SciRuby/nmatrix/blob/293e2fbaa87490366aa55d4cdf7eb76c1c3018a6/lib/nmatrix/mkmf.rb#L56-L58 doesn't seem to do anything (it was changed in https://github.com/SciRuby/nmatrix/pull/530). Was the nmatrix-fftw gem once tested on Windows (@mrkn)?

Also note that I had installed fftw with the command `pacman -S mingw-w64-x86_64-fftw`.

Proof that the test suite passes for nmatrix-fftw passes on Windows:

```
$ bundle exec rake spec nmatrix_plugins="fftw"
... Skip many lines....
If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

60 deprecation warnings total

Finished in 32.7 seconds
1620 examples, 0 failures, 139 pending
C:/msys64/mingw64/bin/ruby.exe -S rspec spec/00_nmatrix_spec.rb spec/01_enum_spec.rb spec/02_slice_spec.rb spec/03_nmatrix_monkeys_spec.rb spec/blas_spec.rb spec/elementwise_spec.rb spec/homogeneous_spec.rb spec/io/fortran_format_spec.rb spec/io/harwell_boeing_spec.rb spec/io_spec.rb spec/lapack_core_spec.rb spec/math_spec.rb spec/nmatrix_yale_spec.rb spec/rspec_spec.rb spec/shortcuts_spec.rb spec/slice_set_spec.rb spec/stat_spec.rb
C:/msys64/mingw64/bin/ruby.exe -S rspec spec/00_nmatrix_spec.rb spec/01_enum_spec.rb spec/02_slice_spec.rb spec/03_nmatrix_monkeys_spec.rb spec/blas_spec.rb spec/elementwise_spec.rb spec/homogeneous_spec.rb spec/io/fortran_format_spec.rb spec/io/harwell_boeing_spec.rb spec/io_spec.rb spec/lapack_core_spec.rb spec/math_spec.rb spec/nmatrix_yale_spec.rb spec/plugins/fftw/fftw_spec.rb spec/rspec_spec.rb spec/shortcuts_spec.rb spec/slice_set_spec.rb spec/stat_spec.rb

$ ruby -v
ruby 2.5.0p0 (2017-12-25 revision 61468) [x64-mingw32]

```