### PR TITLE
Updated bundler dependency version

### DIFF
--- a/nmatrix.gemspec
+++ b/nmatrix.gemspec
@@ -56,7 +56,7 @@ EOF
   gem.required_ruby_version = '>= 1.9'
 
   gem.add_dependency 'packable', '~> 1.3', '>= 1.3.5'
-  gem.add_development_dependency 'bundler', '~>1.6'
+  gem.add_development_dependency 'bundler', '>=1.6'
   gem.add_development_dependency 'pry', '~>0.10'
   gem.add_development_dependency 'rake', '~>10.3'
   gem.add_development_dependency 'rake-compiler', '~>0.8'


### PR DESCRIPTION
Solve the following issue as 2.0.1 is installed by default with `gem install bundler`

\~/workspace/nmatrix (master) $ bundle install
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (\~> 1.6)

  Current Bundler version:
    bundler (2.0.1)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.6)' in any of the relevant sources:
  the local ruby installation