### PR TITLE
Travis fix: Fixes all osx builds and some linux ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,50 +80,72 @@ matrix:
     # The latest stable and head versions of ruby built by clang on OSX
     - os: osx
       compiler: clang
-      rvm: 2.2
+      rvm: ruby-head-clang
       env:
-        - ruby_version=2.4.0-dev USE_OPENBLAS=1
+        - ruby_version=2.5.0 USE_OPENBLAS=1 CC=clang CXX=clang++
     - os: osx
       compiler: clang
-      rvm: 2.2
+      rvm: ruby-head-clang
       env:
-        - ruby_version=2.4.0-dev NO_EXTERNAL_LIB=1
+        - ruby_version=2.5.0 NO_EXTERNAL_LIB=1 CC=clang CXX=clang++
+    # The latest version of Ruby 2.4.x built by clang on OSX
     - os: osx
       compiler: clang
-      rvm: 2.2
+      rvm: 2.4.1-clang
       env:
-        - ruby_version=2.3.0 USE_OPENBLAS=1
+        - ruby_version=2.4.1 USE_OPENBLAS=1 CC=clang CXX=clang++
     - os: osx
       compiler: clang
-      rvm: 2.2
+      rvm: 2.4.1-clang
       env:
-        - ruby_version=2.3.0 NO_EXTERNAL_LIB=1
+        - ruby_version=2.4.1 NO_EXTERNAL_LIB=1 CC=clang CXX=clang++
+    # The latest version of Ruby 2.3.x built by clang on OSX
+    - os: osx
+      compiler: clang
+      rvm: 2.3.4-clang
+      env:
+        - ruby_version=2.3.4 USE_OPENBLAS=1 CC=clang CXX=clang++
+    - os: osx
+      compiler: clang
+      rvm: 2.3.4-clang
+      env:
+        - ruby_version=2.3.4 NO_EXTERNAL_LIB=1 CC=clang CXX=clang++
     # The latest version of Ruby 2.2.x built by clang on OSX
     - os: osx
       compiler: clang
-      rvm: 2.2
+      rvm: 2.2.7-clang
       env:
-        - ruby_version=2.2.4 USE_OPENBLAS=1
+        - ruby_version=2.2.7 USE_OPENBLAS=1 CC=clang CXX=clang++
+    - os: osx
+      compiler: clang
+      rvm: 2.2.7-clang
+      env:
+        - ruby_version=2.2.7 NO_EXTERNAL_LIB=1 CC=clang CXX=clang++
     # The latest version of Ruby 2.1.x built by clang on OSX
     - os: osx
       compiler: clang
-      rvm: 2.2
+      rvm: 2.1.10-clang
       env:
-        - ruby_version=2.1.8 USE_OPENBLAS=1
+        - ruby_version=2.1.10 USE_OPENBLAS=1 CC=clang CXX=clang++
+    - os: osx
+      compiler: clang
+      rvm: 2.1.10-clang
+      env:
+        - ruby_version=2.1.10 NO_EXTERNAL_LIB=1 CC=clang CXX=clang++
   allow_failures:
     # trunk
     - rvm: ruby-head
     - rvm: ruby-head-clang
     - os: osx
       compiler: clang
-      rvm: 2.2
+      rvm: 2.5
       env:
-        - ruby_version=2.4.0-dev USE_OPENBLAS=1
+        - ruby_version=2.5.0 USE_OPENBLAS=1 CC=clang CXX=clang++
     - os: osx
       compiler: clang
-      rvm: 2.2
+      rvm: 2.5
       env:
-        - ruby_version=2.4.0-dev NO_EXTERNAL_LIB=1
+        - ruby_version=2.5.0 NO_EXTERNAL_LIB=1 CC=clang CXX=clang++
 
 notifications:
   irc: "chat.freenode.net#sciruby"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 os:
   - linux
   - osx
-osx_image: xcode7.2
+osx_image: xcode9.2
 env:
   - USE_ATLAS=1       # This configuration installs ATLAS, builds and tests the nmatrix, nmatrix-atlas, and nmatrix-lapacke gems
   - USE_OPENBLAS=1    # Installs OpenBLAS and reference LAPACK, builds and tests nmatrix, nmatrix-lapacke

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: required
 cache: bundler
 os:
-  - linux
+  #- linux
   - osx
 osx_image: xcode9.2
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: required
 cache: bundler
 os:
-  #- linux
+  - linux
   - osx
 osx_image: xcode9.2
 env:
@@ -11,10 +11,10 @@ env:
   - USE_REF=1         # Installs OpenBLAS and reference LAPACK, builds and tests nmatrix, nmatrix-lapacke
   - NO_EXTERNAL_LIB=1 # No external libraries installed, only nmatrix
 rvm:
-  #- 2.0.0-p648
-  #- 2.1.10
-  #- 2.2.7
-  #- 2.3.4
+  - 2.0.0-p648
+  - 2.1.10
+  - 2.2.7
+  - 2.3.4
   - 2.4.2
   - ruby-head
   # The latest stable and head versions built by clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ rvm:
   - 2.4.2
   - ruby-head
   # The latest stable and head versions built by clang
-  - 2.3.0-clang
+  - 2.4.1-clang
   - ruby-head-clang
   # JRuby versions --- experimental, pending merging Prasun's GSoC project.
   - jruby-9.0.5.0 # earliest supported version (uncomment when jruby-head is passing)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ env:
   - USE_REF=1         # Installs OpenBLAS and reference LAPACK, builds and tests nmatrix, nmatrix-lapacke
   - NO_EXTERNAL_LIB=1 # No external libraries installed, only nmatrix
 rvm:
-  - 2.0.0-p648
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
+  #- 2.0.0-p648
+  #- 2.1.8
+  #- 2.2.4
+  #- 2.3.0
   - 2.4.2
   - ruby-head
   # The latest stable and head versions built by clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
   - NO_EXTERNAL_LIB=1 # No external libraries installed, only nmatrix
 rvm:
   #- 2.0.0-p648
-  #- 2.1.8
-  #- 2.2.4
-  #- 2.3.0
+  #- 2.1.10
+  #- 2.2.7
+  #- 2.3.4
   - 2.4.2
   - ruby-head
   # The latest stable and head versions built by clang
@@ -53,11 +53,11 @@ matrix:
     - os: osx
       rvm: 2.0.0-p648
     - os: osx
-      rvm: 2.1.8
+      rvm: 2.1.10
     - os: osx
-      rvm: 2.2.4
+      rvm: 2.2.7
     - os: osx
-      rvm: 2.3.0
+      rvm: 2.3.4
     - os: osx
       rvm: ruby-head
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
       env: USE_OPENBLAS=1
     - rvm: jruby-9.0.5.0
       env: USE_REF=1    
-    # NOTE: The following two ruby versions on OSX are currently unavailable
+    # NOTE: The following ruby versions on OSX are currently unavailable
     - os: osx
       rvm: 2.0.0-p648
     - os: osx
@@ -64,6 +64,10 @@ matrix:
       rvm: 2.3.0-clang
     - os: osx
       rvm: ruby-head-clang
+    # NOTE: The following ruby versions are GCC are we don't want to do
+    #       these ones with osx, which has clang.
+    - os: osx
+      rvm: 2.4.2
     # FIXME: The following configuration is unavailable because ATLAS should be built from source.
     #        We need homebrew formula for ATLAS and its bottle.
     - os: osx

--- a/nmatrix.gemspec
+++ b/nmatrix.gemspec
@@ -56,7 +56,7 @@ EOF
   gem.required_ruby_version = '>= 1.9'
 
   gem.add_dependency 'packable', '~> 1.3', '>= 1.3.5'
-  gem.add_development_dependency 'bundler', '~>1.6'
+  gem.add_development_dependency 'bundler', '>=1.6'
   gem.add_development_dependency 'pry', '~>0.10'
   gem.add_development_dependency 'rake', '~>10.3'
   gem.add_development_dependency 'rake-compiler', '~>0.8'

--- a/travis.sh
+++ b/travis.sh
@@ -48,7 +48,13 @@ then
     yes | gem pristine --all
     yes | gem update --no-document --system --force
     yes | gem update --no-document --force
+
+    if [ "$ruby_version" == "2.2.7" ] || [ "$ruby_version" == "2.1.10" ]; then
+      yes | gem uninstall bundler --force
+    fi
   fi
+
+  
 
   yes | gem install --no-document bundler -v '~> 1.6' --force
 

--- a/travis.sh
+++ b/travis.sh
@@ -46,11 +46,11 @@ then
     )
 
     yes | gem pristine --all
-    yes | gem update --no-document --system
-    yes | gem update --no-document
+    yes | gem update --no-document --system --force
+    yes | gem update --no-document --force
   fi
 
-  yes | gem install --no-document bundler -v '~> 1.6'
+  yes | gem install --no-document bundler -v '~> 1.6' --force
 
   if [ -n "$USE_ATLAS" ]
   then

--- a/travis.sh
+++ b/travis.sh
@@ -79,7 +79,7 @@ then
         sudo apt-get install -y liblapack-dev
         ;;
       osx)
-        brew install homebrew/science/openblas
+        brew install homebrew/core/openblas
         ;;
     esac
   fi

--- a/travis.sh
+++ b/travis.sh
@@ -45,12 +45,12 @@ then
       rbenv install --verbose $ruby_version
     )
 
-    gem pristine --all
-    gem update --no-document --system
-    gem update --no-document
+    yes | gem pristine --all
+    yes | gem update --no-document --system
+    yes | gem update --no-document
   fi
 
-  gem install --no-document bundler -v '~> 1.6'
+  yes | gem install --no-document bundler -v '~> 1.6'
 
   if [ -n "$USE_ATLAS" ]
   then

--- a/travis.sh
+++ b/travis.sh
@@ -49,7 +49,9 @@ then
     yes | gem update --no-document --system --force
     yes | gem update --no-document --force
 
-    if [ "$ruby_version" == "2.2.7" ] || [ "$ruby_version" == "2.1.10" ]; then
+    echo $TRAVIS_RUBY_VERSION
+
+    if [ $TRAVIS_RUBY_VERSION == '2.2.7-clang' ] || [ $TRAVIS_RUBY_VERSION == '2.1.10-clang' ]; then
       yes | gem uninstall bundler --force
     fi
   fi


### PR DESCRIPTION
Fixes:
- Ruby version (older ones) and bundler version conflicts.
- Errors due to homebrew/science migration to homebrew/core
- yN prompt timeout

Also, updated the corresponding ruby 2.1.x, 2.2.x, 2.3.x, 2.4.x to latest versions and removed non-clang and osx pairs.

There is still some exception (Illegal seek - <STDOUT>) generated in some linux builds while running tests that needs to be fixed. I'll try to fix that too and make a different PR for that.