### PR TITLE
Fix gcc capability check

### DIFF
--- a/lib/nmatrix/mkmf.rb
+++ b/lib/nmatrix/mkmf.rb
@@ -29,6 +29,11 @@ end
 
 def find_newer_gplusplus #:nodoc:
   print "checking for apparent GNU g++ binary with C++0x/C++11 support... "
+  major_version = gplusplus_version.split(".").first.to_i
+  # modern GCC has that
+  return true if major_version > 4
+  return false if major_version < 0
+  # legacy approach, check version 4:
   [9,8,7,6,5,4,3].each do |minor|
     ver = "4.#{minor}"
     gpp = "g++-#{ver}"
@@ -48,10 +53,10 @@ def gplusplus_version
   patch = cxxvar.call('__GNUC_PATCHLEVEL__')
 
   raise("unable to determine g++ version (match to get version was nil)") if major.nil? || minor.nil? || patch.nil?
-
-  "#{major}.#{minor}.#{patch}"
+  ver = "#{major}.#{minor}.#{patch}"
+  puts "g++ version discovered: " + ver
+  ver
 end
-
 
 if /cygwin|mingw/ =~ RUBY_PLATFORM
   CONFIG["DLDFLAGS"] << " --output-lib libnmatrix.a"

--- a/lib/nmatrix/mkmf.rb
+++ b/lib/nmatrix/mkmf.rb
@@ -32,13 +32,15 @@ def find_newer_gplusplus #:nodoc:
   major_version = gplusplus_version.split(".").first.to_i
   # modern GCC has that
   return true if major_version > 4
-  return false if major_version < 0
+  return false if major_version < 4
+
   # legacy approach, check version 4:
   [9,8,7,6,5,4,3].each do |minor|
     ver = "4.#{minor}"
     gpp = "g++-#{ver}"
     result = `which #{gpp}`
     next if result.empty?
+
     CONFIG['CXX'] = gpp
     puts ver
     return CONFIG['CXX']


### PR DESCRIPTION
Current implementation supports g++ 4.x only, when checking c++11 support. 

Fix assumes that any g++ newer than 4 does support c++11. 

It allows compiling nmatrix on modern g++ versions.

fixes #630