### PR TITLE
Made installation work with gpp10+ (version > 10)

### DIFF
--- a/lib/nmatrix/mkmf.rb
+++ b/lib/nmatrix/mkmf.rb
@@ -49,7 +49,7 @@ def gplusplus_version
 
   raise("unable to determine g++ version (match to get version was nil)") if major.nil? || minor.nil? || patch.nil?
 
-  [major, minor, patch]
+  [major.to_i, minor.to_i, patch.to_i]
 end
 
 

--- a/lib/nmatrix/mkmf.rb
+++ b/lib/nmatrix/mkmf.rb
@@ -49,7 +49,7 @@ def gplusplus_version
 
   raise("unable to determine g++ version (match to get version was nil)") if major.nil? || minor.nil? || patch.nil?
 
-  "#{major}.#{minor}.#{patch}"
+  [major, minor, patch]
 end
 
 
@@ -69,14 +69,14 @@ if CONFIG['CXX'] == 'clang++'
   $CXX_STANDARD = 'c++11'
 else
   version = gplusplus_version
-  if version < '4.3.0' && CONFIG['CXX'] == 'g++'  # see if we can find a newer G++, unless it's been overridden by user
+  if (version[0] < 4 || version[0] == 4 && version[1] < 3) && CONFIG['CXX'] == 'g++'  # see if we can find a newer G++, unless it's been overridden by user
     if !find_newer_gplusplus
       raise("You need a version of g++ which supports -std=c++0x or -std=c++11. If you're on a Mac and using Homebrew, we recommend using mac-brew-gcc.sh to install a more recent g++.")
     end
     version = gplusplus_version
   end
 
-  if version < '4.7.0'
+  if version[0] < 4 || version[0] == 4 && version[1] < 7
     $CXX_STANDARD = 'c++0x'
   else
     $CXX_STANDARD = 'c++11'


### PR DESCRIPTION
I recently had to install nmatrix gem in a machine with gpp14 running and I noticed that the installation failed because was comparing the version as a string.
I fixed it making the function gplusplus version to return an array of numbers instead of a string, and changing the if conditions.

EDIT: I just noticed that there is already a Pull Requests solving this issue, but i think both PR can be merged since one fixes the find_newer_gplusplus method and another the conditionals checking the version.

fixes #630