### PR TITLE
fix ruby 2.7 keyword parameters warning

### DIFF
--- a/lib/nmatrix/shortcuts.rb
+++ b/lib/nmatrix/shortcuts.rb
@@ -200,7 +200,7 @@ class NMatrix
       #shape.unshift(1) if shape.size == 1
 
       # Then flatten the array.
-      NMatrix.new(shape, params.flatten, options)
+      NMatrix.new(shape, params.flatten, **options)
     end
 
     #

--- a/lib/nmatrix/version.rb
+++ b/lib/nmatrix/version.rb
@@ -29,7 +29,7 @@ class NMatrix
   module VERSION #:nodoc:
     MAJOR = 0
     MINOR = 2
-    TINY = 4
+    TINY = 5
     #PRE = "a"
 
     STRING = [MAJOR, MINOR, TINY].compact.join(".")


### PR DESCRIPTION
Line 203 in shortcuts.rb gives this warning: "Using the last argument as keyword parameters is deprecated".  Just splat it instead now.